### PR TITLE
Ajoute l'internationalisation (i18n) en 6 langues

### DIFF
--- a/app/app.vue
+++ b/app/app.vue
@@ -1,3 +1,15 @@
+<script setup lang="ts">
+// Keep the document <html lang> and default meta in sync with the active locale.
+// Individual pages may still override the title via their own useHead().
+const { t, locale } = useI18n()
+
+useHead(() => ({
+    htmlAttrs: { lang: locale.value },
+    title: t('app.name'),
+    meta: [{ name: 'description', content: t('app.description') }],
+}))
+</script>
+
 <template>
     <NuxtRouteAnnouncer />
     <NuxtLoadingIndicator />

--- a/app/components/CafeMenu.vue
+++ b/app/components/CafeMenu.vue
@@ -22,6 +22,8 @@ const props = defineProps<{
     baristaLink?: string;
 }>();
 
+const { t } = useI18n();
+
 const selectedItem = ref<MenuItem | null>(null);
 const selectedOptions = ref([] as any[]);
 const isOpenOptions = ref(false);
@@ -121,13 +123,13 @@ onBeforeUnmount(() => {
 function orderStatusText(order: any) {
     switch (order.status) {
         case "ordered":
-            return "Your order is being prepared";
+            return t("menu.status.ordered");
         case "completed":
-            return "Your order is ready !";
+            return t("menu.status.completed");
         case "canceled":
-            return "Your order has been canceled";
+            return t("menu.status.canceled");
         default:
-            return "Unknown status";
+            return t("menu.status.unknown");
     }
 }
 
@@ -144,7 +146,7 @@ async function onSendCommand() {
         await props.submitOrder({
             item: selectedItem.value,
             options: optionsPayload,
-            clientName: clientName.value || "Anon",
+            clientName: clientName.value || t("menu.anonymous"),
         });
         selectedOptions.value = [];
         closeItem();
@@ -159,18 +161,21 @@ async function onSendCommand() {
 <template>
     <div class="bg-latte min-h-screen text-coffee">
         <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-6 sm:py-10 flex flex-col min-h-screen">
-            <h1 class="font-bold text-3xl sm:text-4xl mb-6 text-coffee">
-                {{ cafe.name }}
-            </h1>
+            <div class="flex flex-wrap items-center gap-3 mb-6">
+                <h1 class="font-bold text-3xl sm:text-4xl text-coffee">
+                    {{ cafe.name }}
+                </h1>
+                <LanguageSwitcher />
+            </div>
             <NuxtLink v-if="baristaLink" :to="baristaLink">
                 <UButton class="fixed top-4 right-4 z-10 bg-coffee-500 hover:bg-coffee-600 text-white">
-                    Be the barista
+                    {{ $t('menu.beBarista') }}
                     <UIcon name="i-hugeicons:coffee-02" />
                 </UButton>
             </NuxtLink>
             <div class="flex flex-col grow">
                 <h2 class="font-bold text-2xl mb-4 text-coffee">
-                    Menu
+                    {{ $t('menu.heading') }}
                 </h2>
                 <div class="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6 gap-3 sm:gap-4 mb-10">
                 <button v-for="item of items" :key="item.$id" type="button" @click="openItem(item)"
@@ -203,14 +208,14 @@ async function onSendCommand() {
                 </button>
             </div>
             <h2 key="pastOrders" class="font-bold text-2xl mb-4 text-coffee">
-                Past Orders
+                {{ $t('menu.pastOrders') }}
             </h2>
             <div v-if="orders.length" class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3">
                 <UCard v-for="order in orders" :key="order.$id" variant="soft"
                     class="flex flex-col bg-white dark:bg-latte-50 drop-shadow-xl rounded-lg">
                     <div class="flex flex-col justify-between">
                         <div class="font-bold text-2xl text-coffee">
-                            {{ order.item?.name || "Unknown item" }}
+                            {{ order.item?.name || $t('menu.unknownItem') }}
                         </div>
                         <div class="font-mono text-gray-500 dark:text-gray-400 text-sm">
                             #{{ order.$id }}
@@ -228,7 +233,7 @@ async function onSendCommand() {
                             </div>
                             <UButton v-if="order.status === 'ordered'" size="sm" variant="soft" color="error"
                                 loading-auto @click="() => cancelOrder(order.$id)">
-                                Cancel
+                                {{ $t('common.cancel') }}
                             </UButton>
                         </div>
                     </div>
@@ -256,7 +261,7 @@ async function onSendCommand() {
                                     : 'none',
                             }" />
                         <UButton icon="i-lucide-x" color="neutral" variant="solid" size="md" @click="closeItem"
-                            aria-label="Close"
+                            :aria-label="$t('common.close')"
                             class="absolute top-3 right-3 rounded-full bg-white/90 hover:bg-white text-coffee shadow transition-opacity duration-300"
                             :class="showModalExtras ? 'opacity-100' : 'opacity-0'
                                 " />
@@ -299,14 +304,14 @@ async function onSendCommand() {
                                     }"></UTabs>
                             </div>
                         </div>
-                        <UFormField label="Your name" class="mt-4">
-                            <UInput v-model="clientName" placeholder="Your name"
+                        <UFormField :label="$t('menu.yourName')" class="mt-4">
+                            <UInput v-model="clientName" :placeholder="$t('menu.yourName')"
                                 class="bg-white text-coffee focus:ring-coffee-500"></UInput>
                         </UFormField>
                         <div class="flex flex-row justify-end mt-4">
                             <UButton :loading="isOrderSending" size="xl"
                                 class="rounded-full bg-coffee-500 hover:bg-coffee-600 text-white" @click="onSendCommand">
-                                Order</UButton>
+                                {{ $t('menu.order') }}</UButton>
                         </div>
                     </div>
                 </div>

--- a/app/components/LanguageSwitcher.vue
+++ b/app/components/LanguageSwitcher.vue
@@ -1,0 +1,31 @@
+<script setup lang="ts">
+// Compact language picker. With strategy "no_prefix", setLocale() persists the
+// choice in a cookie and updates the UI without changing the URL.
+const { locale, locales, setLocale } = useI18n()
+
+const options = computed(() =>
+    (locales.value as { code: string; name: string }[]).map((l) => ({
+        label: l.name,
+        value: l.code,
+    })),
+)
+
+function onChange(value: string) {
+    setLocale(value as typeof locale.value)
+}
+</script>
+
+<template>
+    <USelect
+        :model-value="locale"
+        :items="options"
+        value-key="value"
+        icon="i-heroicons-language"
+        color="neutral"
+        variant="ghost"
+        size="sm"
+        :aria-label="$t('languageSwitcher.label')"
+        :ui="{ base: 'text-coffee' }"
+        @update:model-value="onChange"
+    />
+</template>

--- a/app/pages/[cafeId]/barista/cafe.vue
+++ b/app/pages/[cafeId]/barista/cafe.vue
@@ -3,25 +3,30 @@
         <UContainer class="py-8">
             <UCard class="bg-white dark:bg-latte-50 ring-1 ring-gray-200 dark:ring-gray-700">
                 <template #header>
-                    <h1 class="text-xl font-semibold leading-tight text-coffee">
-                        Share Your Page
-                    </h1>
-                    <p class="text-sm text-gray-500 dark:text-gray-400">
-                        Share this page using the URL or QR code below.
-                    </p>
+                    <div class="flex items-start justify-between gap-2">
+                        <div>
+                            <h1 class="text-xl font-semibold leading-tight text-coffee">
+                                {{ $t('cafeSettings.share.title') }}
+                            </h1>
+                            <p class="text-sm text-gray-500 dark:text-gray-400">
+                                {{ $t('cafeSettings.share.subtitle') }}
+                            </p>
+                        </div>
+                        <LanguageSwitcher class="shrink-0" />
+                    </div>
                 </template>
 
                 <div class="space-y-6">
-                    <UFormGroup label="Page URL" name="pageUrl" help="This is the direct link to your page.">
+                    <UFormGroup :label="$t('cafeSettings.share.pageUrlLabel')" name="pageUrl" :help="$t('cafeSettings.share.pageUrlHelp')">
                         <div class="flex items-center gap-2">
-                            <UInput :model-value="pageUrl" readonly class="flex-grow" placeholder="Generating URL..."
+                            <UInput :model-value="pageUrl" readonly class="flex-grow" :placeholder="$t('cafeSettings.share.generatingUrl')"
                                 icon="i-heroicons-link" size="lg" />
                             <UButton @click="handleCopyUrl" :icon="copied
                                     ? 'i-heroicons-check-circle-20-solid'
                                     : 'i-heroicons-clipboard-document-20-solid'
                                 " :color="copied ? 'success' : 'primary'" variant="solid" square size="lg"
                                 :disabled="!pageUrl">
-                                {{ copied ? "Copied!" : "Copy" }}
+                                {{ copied ? $t("common.copied") : $t("common.copy") }}
                             </UButton>
                         </div>
                     </UFormGroup>
@@ -30,11 +35,10 @@
 
                     <div>
                         <h2 class="text-lg font-medium text-coffee mb-2">
-                            QR Code
+                            {{ $t('cafeSettings.qr.title') }}
                         </h2>
                         <p class="text-sm text-gray-500 dark:text-gray-400 mb-3">
-                            Scan this QR code with a mobile device to open the
-                            page.
+                            {{ $t('cafeSettings.qr.subtitle') }}
                         </p>
                         <div v-if="pageUrl" ref="qrCodeContainerRef"
                             class="flex justify-center items-center p-4 bg-white rounded-lg shadow max-w-xs mx-auto border border-gray-100">
@@ -48,13 +52,12 @@
                         <div v-if="pageUrl" class="flex justify-center mt-4">
                             <UButton @click="handleDownloadQrCode"
                                 icon="i-heroicons-arrow-down-tray-20-solid" variant="solid" size="lg">
-                                Download PNG
+                                {{ $t('cafeSettings.qr.downloadPng') }}
                             </UButton>
                         </div>
                         <div v-else class="text-center text-gray-500 py-10">
                             <p class="mb-2">
-                                Page URL not available, QR code cannot be
-                                generated.
+                                {{ $t('cafeSettings.qr.unavailable') }}
                             </p>
                             <USkeleton class="h-[220px] w-[220px mx-auto" />
                         </div>
@@ -66,17 +69,17 @@
             <UCard class="bg-white ring-1 ring-gray-200 dark:ring-gray-700 dark:bg-latte-50">
                 <template #header>
                     <h1 class="text-xl font-semibold leading-tight text-coffee">
-                        Update Cafe Name
+                        {{ $t('cafeSettings.updateName.title') }}
                     </h1>
                     <p class="text-sm text-gray-500">
-                        Modify your cafe's name.
+                        {{ $t('cafeSettings.updateName.subtitle') }}
                     </p>
                 </template>
 
                 <div class="space-y-6">
-                    <UFormGroup label="Cafe Name" name="cafeNameUpdate" help="Enter the new name for your cafe.">
+                    <UFormGroup :label="$t('cafeSettings.updateName.label')" name="cafeNameUpdate" :help="$t('cafeSettings.updateName.help')">
                         <div class="flex items-center gap-2">
-                            <UInput v-model="cafeNameInput" placeholder="Enter new cafe name" class="flex-grow"
+                            <UInput v-model="cafeNameInput" :placeholder="$t('cafeSettings.updateName.placeholder')" class="flex-grow"
                                 icon="i-heroicons-identification-20-solid" size="lg" :disabled="!currentCafeId || isLoadingUpdateName
                                     " />
                             <UButton @click="handleUpdateCafeName" :loading="isLoadingUpdateName" :disabled="!cafeNameInput.trim() ||
@@ -85,8 +88,8 @@
                                 " icon="i-heroicons-arrow-path-20-solid" variant="solid" size="lg">
                                 {{
                                     isLoadingUpdateName
-                                        ? "Updating..."
-                                        : "Update"
+                                        ? $t("cafeSettings.updateName.updating")
+                                        : $t("cafeSettings.updateName.update")
                                 }}
                             </UButton>
                         </div>
@@ -100,16 +103,16 @@
             <UCard class="bg-white ring-1 ring-gray-200 dark:ring-gray-700 dark:bg-latte-50">
                 <template #header>
                     <h1 class="text-xl font-semibold leading-tight text-coffee">
-                        Custom Images
+                        {{ $t('cafeSettings.customImages.title') }}
                     </h1>
                     <p class="text-sm text-gray-500">
-                        Upload your own images to use in your menu items.
+                        {{ $t('cafeSettings.customImages.subtitle') }}
                     </p>
                 </template>
 
                 <div class="space-y-4">
                     <UButton @click="fileInputRef?.click()" icon="i-heroicons-arrow-up-tray-20-solid"
-                        label="Upload Image" variant="solid" size="lg" />
+                        :label="$t('cafeSettings.customImages.upload')" variant="solid" size="lg" />
                     <input ref="fileInputRef" type="file" accept="image/*" class="hidden" @change="handleUploadImage" />
 
                     <div v-if="isLoadingImages" class="flex gap-4">
@@ -118,7 +121,7 @@
                     <div v-else-if="customImages.length === 0" class="text-center text-gray-500 py-8">
                         <UIcon name="i-heroicons-photo" class="mx-auto h-12 w-12 text-gray-400" />
                         <p class="mt-2">
-                            No custom images yet. Upload one to get started.
+                            {{ $t('cafeSettings.customImages.empty') }}
                         </p>
                     </div>
                     <div v-else class="grid grid-cols-3 sm:grid-cols-4 md:grid-cols-6 gap-4">
@@ -141,7 +144,7 @@
             <UCard class="bg-white ring-1 ring-gray-200 dark:ring-gray-700 dark:bg-latte-50">
                 <template #header>
                     <h1 class="text-xl font-semibold leading-tight text-coffee">
-                        About & Support
+                        {{ $t('cafeSettings.about.title') }}
                     </h1>
                 </template>
 
@@ -151,14 +154,13 @@
                             <UIcon name="i-simple-icons-github" class="w-6 h-6 text-gray-900 dark:text-white" />
                         </div>
                         <div>
-                            <h3 class="font-medium text-coffee">Open Source</h3>
+                            <h3 class="font-medium text-coffee">{{ $t('cafeSettings.about.openSourceTitle') }}</h3>
                             <p class="text-sm text-gray-500 dark:text-gray-400 mb-2">
-                                This project is somewhat open source. The appwrite server configuration
-                                available on Github is probably outdated, reach out if you need anything.
+                                {{ $t('cafeSettings.about.openSourceText') }}
                             </p>
                             <UButton to="https://github.com/Karalix/micro-cafe" target="_blank" variant="link"
                                 class="p-0">
-                                View on GitHub
+                                {{ $t('cafeSettings.about.viewOnGithub') }}
                             </UButton>
                         </div>
                     </div>
@@ -171,13 +173,13 @@
                         </div>
                         <div>
                             <h3 class="font-medium text-coffee">
-                                Contact the Maker
+                                {{ $t('cafeSettings.about.contactTitle') }}
                             </h3>
                             <p class="text-sm text-gray-500 dark:text-gray-400 mb-2">
-                                Built by Alix. Reach out if you need anything.
+                                {{ $t('cafeSettings.about.contactText') }}
                             </p>
                             <UButton to="https://krlx.fr" target="_blank" color="primary" variant="link" class="p-0">
-                                What about hiring me for your next project ?
+                                {{ $t('cafeSettings.about.hireText') }}
                             </UButton>
                         </div>
                     </div>
@@ -188,16 +190,14 @@
                         </div>
                         <div>
                             <h3 class="font-medium text-coffee">
-                                Support My Tiny Café
+                                {{ $t('cafeSettings.about.supportTitle') }}
                             </h3>
                             <p class="text-sm text-gray-500 dark:text-gray-400 mb-2">
-                                My Tiny Café is available free of charge, but if
-                                you enjoy using it, consider supporting its
-                                hosting costs.
+                                {{ $t('cafeSettings.about.supportText') }}
                             </p>
                             <UButton to="https://buymeacoffee.com/krlx" target="_blank" color="primary" variant="link"
                                 class="p-0">
-                                Support on Buy Me a Coffee
+                                {{ $t('cafeSettings.about.supportButton') }}
                             </UButton>
                         </div>
                     </div>
@@ -208,18 +208,16 @@
             <UCard class="bg-white ring-1 ring-red-200 dark:ring-red-900/40 dark:bg-latte-50">
                 <template #header>
                     <h1 class="text-xl font-semibold leading-tight text-red-600">
-                        Delete Account
+                        {{ $t('cafeSettings.delete.title') }}
                     </h1>
                     <p class="text-sm text-gray-500 dark:text-gray-400">
-                        Permanently delete your café, its menu, all orders,
-                        any custom images, and your account. This action
-                        cannot be undone.
+                        {{ $t('cafeSettings.delete.subtitle') }}
                     </p>
                 </template>
 
                 <UButton @click="openDeleteModal" icon="i-heroicons-trash-20-solid" color="error" variant="soft"
                     size="lg" :disabled="!currentCafeId">
-                    Delete my account
+                    {{ $t('cafeSettings.delete.button') }}
                 </UButton>
             </UCard>
         </UContainer>
@@ -228,31 +226,33 @@
             <template #content>
                 <div class="p-6 space-y-4">
                     <h2 class="text-lg font-semibold text-red-600">
-                        Delete your account permanently?
+                        {{ $t('cafeSettings.delete.modalTitle') }}
                     </h2>
                     <p class="text-sm text-gray-600 dark:text-gray-300">
-                        This will permanently delete:
+                        {{ $t('cafeSettings.delete.modalIntro') }}
                     </p>
                     <ul class="list-disc list-inside text-sm text-gray-600 dark:text-gray-300 space-y-1">
-                        <li>your café <strong>{{ currentCafeId }}</strong></li>
-                        <li>its menu items and all past orders</li>
-                        <li v-if="isPremium">your custom images</li>
-                        <li>your account (you will not be able to log in again)</li>
+                        <i18n-t keypath="cafeSettings.delete.modalListCafe" tag="li">
+                            <template #id><strong>{{ currentCafeId }}</strong></template>
+                        </i18n-t>
+                        <li>{{ $t('cafeSettings.delete.modalListMenu') }}</li>
+                        <li v-if="isPremium">{{ $t('cafeSettings.delete.modalListImages') }}</li>
+                        <li>{{ $t('cafeSettings.delete.modalListAccount') }}</li>
                     </ul>
-                    <UFormGroup :label="`Type &quot;${currentCafeId}&quot; to confirm`" name="deleteConfirm">
+                    <UFormGroup :label="$t('cafeSettings.delete.confirmLabel', { cafeId: currentCafeId })" name="deleteConfirm">
                         <UInput v-model="deleteConfirmInput" :placeholder="currentCafeId" size="lg"
                             :disabled="isDeletingAccount" />
                     </UFormGroup>
                     <div class="flex justify-end gap-2 pt-2">
                         <UButton @click="isDeleteModalOpen = false" color="neutral" variant="ghost"
                             :disabled="isDeletingAccount">
-                            Cancel
+                            {{ $t('common.cancel') }}
                         </UButton>
                         <UButton @click="handleDeleteAccount" color="error" variant="solid" :loading="isDeletingAccount"
                             :disabled="deleteConfirmInput.trim() !== currentCafeId ||
                                 isDeletingAccount
                                 ">
-                            Delete permanently
+                            {{ $t('cafeSettings.delete.deletePermanently') }}
                         </UButton>
                     </div>
                 </div>
@@ -263,25 +263,25 @@
             <UCard class="bg-white ring-1 ring-gray-200 dark:ring-gray-700 dark:bg-latte-50">
                 <template #header>
                     <h1 class="text-xl font-semibold leading-tight text-coffee">
-                        Session
+                        {{ $t('cafeSettings.session.title') }}
                     </h1>
                     <p class="text-sm text-gray-500 dark:text-gray-400">
-                        Sign out of this device. You can sign back in anytime.
+                        {{ $t('cafeSettings.session.subtitle') }}
                     </p>
                 </template>
 
                 <UButton @click="logout" icon="i-heroicons-arrow-right-on-rectangle-20-solid" color="neutral"
                     variant="outline" size="lg">
-                    Logout
+                    {{ $t('cafeSettings.session.logout') }}
                 </UButton>
             </UCard>
         </UContainer>
         <UNavigationMenu
             class="fixed bottom-4 my-4 left-1/2 -translate-x-1/2 flex flex-row justify-between px-2 rounded-lg bg-white drop-shadow-md"
             :items="[
-                { label: 'Orders', to: `/${route.params.cafeId}/barista` },
-                { label: 'Menu', to: `/${route.params.cafeId}/barista/menu` },
-                { label: 'Cafe', to: `/${route.params.cafeId}/barista/cafe` },
+                { label: $t('nav.orders'), to: `/${route.params.cafeId}/barista` },
+                { label: $t('nav.menu'), to: `/${route.params.cafeId}/barista/menu` },
+                { label: $t('nav.cafe'), to: `/${route.params.cafeId}/barista/cafe` },
             ]" />
     </div>
 </template>
@@ -295,6 +295,7 @@ import QrCodeVue from "qrcode.vue"; // Import QR Code component
 import { useClipboard } from "@vueuse/core"; // For advanced clipboard functionality
 
 const { add: addToast } = useToast(); // Optional: For success/error notifications
+const { t } = useI18n();
 
 const { $appwrite } = useNuxtApp();
 const databases = $appwrite.databases;
@@ -352,8 +353,8 @@ const handleUploadImage = async (event: Event) => {
             Permission.delete(Role.user(userId.value)),
         ]);
         toast.add({
-            title: "Image Uploaded",
-            description: `"${file.name}" has been uploaded.`,
+            title: t("cafeSettings.toast.imageUploadedTitle"),
+            description: t("cafeSettings.toast.imageUploadedDesc", { name: file.name }),
             color: "primary",
             icon: "i-heroicons-check-circle",
         });
@@ -361,8 +362,8 @@ const handleUploadImage = async (event: Event) => {
     } catch (error: any) {
         console.error("Failed to upload image:", error);
         toast.add({
-            title: "Upload Failed",
-            description: error.message || "Could not upload the image.",
+            title: t("cafeSettings.toast.uploadFailedTitle"),
+            description: error.message || t("cafeSettings.toast.uploadFailedDesc"),
             color: "error",
             icon: "i-heroicons-x-circle",
         });
@@ -374,7 +375,7 @@ const handleUploadImage = async (event: Event) => {
 const handleDeleteImage = async (fileId: string) => {
     if (
         !window.confirm(
-            "Delete this image? Items using it will show a broken image.",
+            t("cafeSettings.toast.confirmDeleteImage"),
         )
     )
         return;
@@ -382,8 +383,8 @@ const handleDeleteImage = async (fileId: string) => {
     try {
         await storage.deleteFile("images", fileId);
         toast.add({
-            title: "Image Deleted",
-            description: "The image has been deleted.",
+            title: t("cafeSettings.toast.imageDeletedTitle"),
+            description: t("cafeSettings.toast.imageDeletedDesc"),
             color: "primary",
             icon: "i-heroicons-check-circle",
         });
@@ -391,8 +392,8 @@ const handleDeleteImage = async (fileId: string) => {
     } catch (error: any) {
         console.error("Failed to delete image:", error);
         toast.add({
-            title: "Delete Failed",
-            description: error.message || "Could not delete the image.",
+            title: t("cafeSettings.toast.deleteFailedTitle"),
+            description: error.message || t("cafeSettings.toast.deleteFailedDesc"),
             color: "error",
             icon: "i-heroicons-x-circle",
         });
@@ -423,8 +424,8 @@ const isLoadingUpdateName = ref<boolean>(false);
 async function handleUpdateCafeName(): Promise<void> {
     if (!currentCafeId.value) {
         toast.add({
-            title: "Error",
-            description: "Cafe ID is not available. Cannot update name.",
+            title: t("cafeSettings.toast.errorTitle"),
+            description: t("cafeSettings.toast.cafeIdUnavailable"),
             color: "error",
             icon: "i-heroicons-x-circle-20-solid",
         });
@@ -433,8 +434,8 @@ async function handleUpdateCafeName(): Promise<void> {
 
     if (!cafeNameInput.value.trim()) {
         toast.add({
-            title: "Validation Error",
-            description: "Cafe name cannot be empty.",
+            title: t("cafeSettings.toast.validationErrorTitle"),
+            description: t("cafeSettings.toast.cafeNameEmpty"),
             color: "warning",
             icon: "i-heroicons-exclamation-circle-20-solid",
         });
@@ -448,16 +449,16 @@ async function handleUpdateCafeName(): Promise<void> {
         });
 
         toast.add({
-            title: "Success!",
-            description: `Cafe name updated to "${cafeNameInput.value}".`,
+            title: t("cafeSettings.toast.successTitle"),
+            description: t("cafeSettings.toast.cafeNameUpdated", { name: cafeNameInput.value }),
             color: "primary",
             icon: "i-heroicons-check-circle-20-solid",
         });
     } catch (error) {
         console.error("Failed to update cafe name:", error);
         toast.add({
-            title: "Update Failed",
-            description: "Could not update cafe name. Please try again.",
+            title: t("cafeSettings.toast.updateFailedTitle"),
+            description: t("cafeSettings.toast.updateNameFailedDesc"),
             color: "error",
             icon: "i-heroicons-x-circle-20-solid",
         });
@@ -485,9 +486,9 @@ watch(
             if (process.client && route.fullPath !== "/" && route.name) {
                 // Ensure route is resolved
                 toast.add({
-                    title: "Missing Cafe ID",
+                    title: t("cafeSettings.toast.missingCafeIdTitle"),
                     description:
-                        "The unique identifier for the cafe is missing from the URL.",
+                        t("cafeSettings.toast.missingCafeIdDesc"),
                     color: "warning",
                     icon: "i-heroicons-exclamation-triangle-20-solid",
                 });
@@ -529,8 +530,8 @@ const {
 async function handleCopyUrl(): Promise<void> {
     if (!pageUrl.value) {
         toast.add({
-            title: "URL Not Available",
-            description: "The page URL is not ready to be copied.",
+            title: t("cafeSettings.toast.urlNotAvailableTitle"),
+            description: t("cafeSettings.toast.urlNotAvailableDesc"),
             color: "warning",
             icon: "i-heroicons-exclamation-circle-20-solid",
         });
@@ -539,9 +540,9 @@ async function handleCopyUrl(): Promise<void> {
 
     if (!clipboardIsSupported.value) {
         toast.add({
-            title: "Clipboard Access Denied",
+            title: t("cafeSettings.toast.clipboardDeniedTitle"),
             description:
-                "Your browser settings prevent clipboard access, or it's not supported.",
+                t("cafeSettings.toast.clipboardDeniedDesc"),
             color: "error",
             icon: "i-heroicons-no-symbol-20-solid",
         });
@@ -556,16 +557,16 @@ async function handleCopyUrl(): Promise<void> {
         if (copied.value) {
             // `copied` ref from useClipboard indicates success
             toast.add({
-                title: "URL Copied!",
-                description: "The page URL has been copied to your clipboard.",
+                title: t("cafeSettings.toast.urlCopiedTitle"),
+                description: t("cafeSettings.toast.urlCopiedDesc"),
                 color: "primary",
                 icon: "i-heroicons-check-circle-20-solid",
             });
         } else {
             // This might occur if copy() promise resolves but `copied` flag isn't set (e.g. legacy mode issues)
             toast.add({
-                title: "Copy Unconfirmed",
-                description: "Attempted to copy. Please verify your clipboard.",
+                title: t("cafeSettings.toast.copyUnconfirmedTitle"),
+                description: t("cafeSettings.toast.copyUnconfirmedDesc"),
                 color: "primary",
                 icon: "i-heroicons-information-circle-20-solid",
             });
@@ -573,9 +574,9 @@ async function handleCopyUrl(): Promise<void> {
     } catch (error) {
         console.error("Failed to copy URL:", error);
         toast.add({
-            title: "Copy Failed",
+            title: t("cafeSettings.toast.copyFailedTitle"),
             description:
-                "An error occurred while trying to copy the URL. Please copy it manually.",
+                t("cafeSettings.toast.copyFailedDesc"),
             color: "error",
             icon: "i-heroicons-x-circle-20-solid",
         });
@@ -588,8 +589,8 @@ async function handleDownloadQrCode(): Promise<void> {
     const svgElement = qrCodeContainerRef.value?.querySelector("svg");
     if (!svgElement) {
         toast.add({
-            title: "Download Failed",
-            description: "QR code is not ready yet. Please try again.",
+            title: t("cafeSettings.toast.downloadFailedTitle"),
+            description: t("cafeSettings.toast.qrNotReady"),
             color: "error",
             icon: "i-heroicons-x-circle-20-solid",
         });
@@ -647,16 +648,16 @@ async function handleDownloadQrCode(): Promise<void> {
         URL.revokeObjectURL(downloadUrl);
 
         toast.add({
-            title: "QR Code Downloaded",
-            description: "The QR code PNG has been saved.",
+            title: t("cafeSettings.toast.qrDownloadedTitle"),
+            description: t("cafeSettings.toast.qrDownloadedDesc"),
             color: "primary",
             icon: "i-heroicons-check-circle-20-solid",
         });
     } catch (error) {
         console.error("Failed to download QR code:", error);
         toast.add({
-            title: "Download Failed",
-            description: "Could not generate the PNG file. Please try again.",
+            title: t("cafeSettings.toast.downloadFailedTitle"),
+            description: t("cafeSettings.toast.qrGenerateFailed"),
             color: "error",
             icon: "i-heroicons-x-circle-20-solid",
         });
@@ -667,8 +668,8 @@ const logout = async () => {
     await account.deleteSession("current");
     navigateTo("/");
     addToast({
-        title: "Logged out",
-        description: "You have been logged out",
+        title: t("cafeSettings.toast.loggedOutTitle"),
+        description: t("cafeSettings.toast.loggedOutDesc"),
         color: "primary",
     });
 };
@@ -706,8 +707,8 @@ async function handleDeleteAccount() {
         await account.updateStatus();
 
         toast.add({
-            title: "Account deleted",
-            description: "Your account and café have been permanently deleted.",
+            title: t("cafeSettings.toast.accountDeletedTitle"),
+            description: t("cafeSettings.toast.accountDeletedDesc"),
             color: "primary",
             icon: "i-heroicons-check-circle-20-solid",
         });
@@ -716,10 +717,10 @@ async function handleDeleteAccount() {
     } catch (error: any) {
         console.error("Failed to delete account:", error);
         toast.add({
-            title: "Deletion Failed",
+            title: t("cafeSettings.toast.deletionFailedTitle"),
             description:
                 error.message ||
-                "Could not delete your account. Please try again.",
+                t("cafeSettings.toast.deletionFailedDesc"),
             color: "error",
             icon: "i-heroicons-x-circle-20-solid",
         });

--- a/app/pages/[cafeId]/barista/index.vue
+++ b/app/pages/[cafeId]/barista/index.vue
@@ -86,41 +86,41 @@ const cancelOrder = async (orderId: string) => {
 
 <template>
     <div class="bg-latte p-8 min-h-screen flex flex-col">
-        <h1 class="font-bold text-3xl mb-4 ml-4 sm:ml-6 text-coffee">Order</h1>
-        <UButton v-if="showNotificationPrompt" @click="requestNotificationPermission" class="mb-4 ml-4 sm:ml-6 bg-coffee-500 hover:bg-coffee-600 text-white">Receive a notification when a new order is placed</UButton>
+        <h1 class="font-bold text-3xl mb-4 ml-4 sm:ml-6 text-coffee">{{ $t('baristaOrders.title') }}</h1>
+        <UButton v-if="showNotificationPrompt" @click="requestNotificationPermission" class="mb-4 ml-4 sm:ml-6 bg-coffee-500 hover:bg-coffee-600 text-white">{{ $t('baristaOrders.enableNotifications') }}</UButton>
         
         <div v-if="orders.length === 0 && pastOrders.length === 0" class="flex flex-col items-center justify-center grow py-12 text-center">
             <UIcon name="i-heroicons-inbox" class="w-16 h-16 text-gray-400 dark:text-gray-500 mb-4" />
-            <h3 class="text-xl font-semibold text-coffee mb-2">No orders yet</h3>
-            <p class="text-gray-600 dark:text-gray-400 mb-6">Share your café page to start receiving orders!</p>
-            <UButton :to="`/${route.params.cafeId}/barista/cafe`" class="bg-coffee-500 hover:bg-coffee-600 text-white" label="Share my Café" icon="i-heroicons-share" />
+            <h3 class="text-xl font-semibold text-coffee mb-2">{{ $t('baristaOrders.emptyTitle') }}</h3>
+            <p class="text-gray-600 dark:text-gray-400 mb-6">{{ $t('baristaOrders.emptyText') }}</p>
+            <UButton :to="`/${route.params.cafeId}/barista/cafe`" class="bg-coffee-500 hover:bg-coffee-600 text-white" :label="$t('baristaOrders.shareCafe')" icon="i-heroicons-share" />
         </div>
 
         <UCard
            v-for="order in orders"
            :key="order.$id"
            class="mb-4 text-coffee bg-white dark:bg-latte-50 drop-shadow-sm rounded-2xl hover:cursor-pointer hover:bg-latte-50 dark:hover:bg-latte-100 active:drop-shadow-md transition-all ring-1 ring-gray-200 dark:ring-gray-700">
-            <div>{{ order.item?.name || 'Unknown item' }} - {{ order.clientName }} - {{ order.options.join(', ') }}</div>
+            <div>{{ order.item?.name || $t('baristaOrders.unknownItem') }} - {{ order.clientName }} - {{ order.options.join(', ') }}</div>
             <template #footer>
                 <div class="flex flex-row space-x-3 justify-end">
-                    <UButton color="error" variant="ghost" @click="cancelOrder(order.$id)">Cancel</UButton>
-                    <UButton color="primary" variant="solid" @click="completeOrder(order.$id)">Complete</UButton>
+                    <UButton color="error" variant="ghost" @click="cancelOrder(order.$id)">{{ $t('baristaOrders.cancel') }}</UButton>
+                    <UButton color="primary" variant="solid" @click="completeOrder(order.$id)">{{ $t('baristaOrders.complete') }}</UButton>
                 </div>
             </template>
         </UCard>
-        <h2 class="font-bold text-xl mb-4 ml-4 sm:ml-6 text-coffee">Past Orders</h2>
+        <h2 class="font-bold text-xl mb-4 ml-4 sm:ml-6 text-coffee">{{ $t('baristaOrders.pastOrders') }}</h2>
         <UCard
             v-for="order in pastOrders"
             :key="order.$id"
             class="mb-4 text-gray-600 dark:text-gray-400 bg-white dark:bg-latte-50 drop-shadow-sm rounded-2xl hover:cursor-pointer hover:bg-latte-50 dark:hover:bg-latte-100 active:drop-shadow-md transition-all ring-1 ring-gray-200 dark:ring-gray-700">
-            <div>{{ order.item?.name || 'Unknown item'  }} - {{ order.clientName }} - {{ order.options.join(', ') }}</div>
+            <div>{{ order.item?.name || $t('baristaOrders.unknownItem') }} - {{ order.clientName }} - {{ order.options.join(', ') }}</div>
             <template #footer>
                 <div class="flex flex-row space-x-3 justify-end">
-                    <div>{{ order.status  }}</div>
+                    <div>{{ $t(`baristaOrders.statusLabel.${order.status}`) }}</div>
                 </div>
             </template>
         </UCard>
         <div class="flex flex-col justify-center grow"></div>
-              <UNavigationMenu class="fixed bottom-4 my-4 left-1/2 -translate-x-1/2 flex flex-row justify-between px-2 rounded-lg bg-white dark:bg-latte-50 drop-shadow-md" :items="[{label: 'Orders', to: `/${route.params.cafeId}/barista`}, {label: 'Menu', to: `/${route.params.cafeId}/barista/menu`}, {label: 'Cafe', to: `/${route.params.cafeId}/barista/cafe`}]" />
+              <UNavigationMenu class="fixed bottom-4 my-4 left-1/2 -translate-x-1/2 flex flex-row justify-between px-2 rounded-lg bg-white dark:bg-latte-50 drop-shadow-md" :items="[{label: $t('nav.orders'), to: `/${route.params.cafeId}/barista`}, {label: $t('nav.menu'), to: `/${route.params.cafeId}/barista/menu`}, {label: $t('nav.cafe'), to: `/${route.params.cafeId}/barista/cafe`}]" />
     </div>
 </template>

--- a/app/pages/[cafeId]/barista/menu.vue
+++ b/app/pages/[cafeId]/barista/menu.vue
@@ -18,27 +18,29 @@ interface ItemDocument extends Models.Document {
     cafeId: CafeDocument; // Based on example, cafeId is populated on read
 }
 
-const availableImages = [
-    { label: 'Bobba', value: '/images-cafe/bobba.png' },
-    { label: 'Café', value: '/images-cafe/cafe.png' },
-    { label: 'Cookie', value: '/images-cafe/cookie.png' },
-    { label: 'Emporter', value: '/images-cafe/emporter.png' },
-    { label: 'Gaiwan', value: '/images-cafe/gaiwan.png' },
-    { label: 'Jus', value: '/images-cafe/jus.png' },
-    { label: 'Latte', value: '/images-cafe/latte.png' },
-    { label: 'Muffin', value: '/images-cafe/muffin.png' },
-    { label: 'Mug', value: '/images-cafe/mug.png' },
-    { label: 'Tartine', value: '/images-cafe/tartine.png' },
-    { label: 'Thé', value: '/images-cafe/the.png' },
-    { label: 'Yaourt', value: '/images-cafe/yaourt.png' },
-]
-
 const route = useRoute()
 const toast = useToast()
+const { t } = useI18n()
 const items = ref<ItemDocument[]>([])
 const cafe = ref<CafeDocument | null>(null)
 const isLoadingCafe = ref(true)
 const isLoadingItems = ref(true)
+
+// Built-in image gallery. Labels are localized; the file paths stay constant.
+const availableImages = computed(() => [
+    { label: t('baristaMenu.images.bobba'), value: '/images-cafe/bobba.png' },
+    { label: t('baristaMenu.images.cafe'), value: '/images-cafe/cafe.png' },
+    { label: t('baristaMenu.images.cookie'), value: '/images-cafe/cookie.png' },
+    { label: t('baristaMenu.images.emporter'), value: '/images-cafe/emporter.png' },
+    { label: t('baristaMenu.images.gaiwan'), value: '/images-cafe/gaiwan.png' },
+    { label: t('baristaMenu.images.jus'), value: '/images-cafe/jus.png' },
+    { label: t('baristaMenu.images.latte'), value: '/images-cafe/latte.png' },
+    { label: t('baristaMenu.images.muffin'), value: '/images-cafe/muffin.png' },
+    { label: t('baristaMenu.images.mug'), value: '/images-cafe/mug.png' },
+    { label: t('baristaMenu.images.tartine'), value: '/images-cafe/tartine.png' },
+    { label: t('baristaMenu.images.the'), value: '/images-cafe/the.png' },
+    { label: t('baristaMenu.images.yaourt'), value: '/images-cafe/yaourt.png' },
+])
 
 const { $appwrite } = useNuxtApp()
 const databases = $appwrite.databases
@@ -51,9 +53,9 @@ const customImages = ref<{ label: string; value: string }[]>([])
 
 const allAvailableImages = computed(() => {
     if (customImages.value.length > 0) {
-        return [...availableImages, ...customImages.value]
+        return [...availableImages.value, ...customImages.value]
     }
-    return availableImages
+    return availableImages.value
 })
 
 const loadPremiumImages = async () => {
@@ -96,7 +98,7 @@ const fetchCafeDetails = async (cafeId: string): Promise<void> => {
         cafe.value = await databases.getDocument<CafeDocument>('cafe', 'cafe', cafeId);
     } catch (error) {
         console.error("Failed to fetch cafe:", error);
-        toast.add({ title: 'Error Loading Cafe', description: 'The requested cafe could not be found or loaded.', color: 'error', icon: 'i-heroicons-exclamation-triangle' });
+        toast.add({ title: t('baristaMenu.toast.errorLoadingCafeTitle'), description: t('baristaMenu.toast.errorLoadingCafeDesc'), color: 'error', icon: 'i-heroicons-exclamation-triangle' });
         navigateTo('/invalid-cafe');
     } finally {
         isLoadingCafe.value = false;
@@ -122,7 +124,7 @@ const fetchItems = async (): Promise<void> => {
         items.value = response.documents;
     } catch (error) {
         console.error("Failed to fetch items:", error);
-        toast.add({ title: 'Error Loading Menu', description: 'Could not load menu items.', color: 'error', icon: 'i-heroicons-exclamation-circle' });
+        toast.add({ title: t('baristaMenu.toast.errorLoadingMenuTitle'), description: t('baristaMenu.toast.errorLoadingMenuDesc'), color: 'error', icon: 'i-heroicons-exclamation-circle' });
         items.value = []; // Clear items on error
     } finally {
         isLoadingItems.value = false;
@@ -133,7 +135,7 @@ onMounted(async () => {
     const cafeIdParam = route.params.cafeId as string;
     if (!cafeIdParam) {
         console.error("Cafe ID is missing in route params.");
-        toast.add({ title: 'Error', description: 'Cafe ID is missing.', color: 'error' });
+        toast.add({ title: t('baristaMenu.toast.errorTitle'), description: t('baristaMenu.toast.cafeIdMissing'), color: 'error' });
         navigateTo('/invalid-cafe'); // Or some other error page
         return;
     }
@@ -188,7 +190,7 @@ const openEditItemModal = (item: ItemDocument): void => {
     });
     showModal.value = true;
 };
-            
+
 
 const addNewStructuredOption = (): void => {
     currentStructuredOptions.value.push({id: '', name: '', isBoolean: true, values: false });
@@ -232,16 +234,16 @@ const addValueToOptionList = (optionIndex: number): void => {
  */
 const handleDeleteItem = async (itemId: string): Promise<void> => {
     // Consider using a Nuxt UI modal for confirmation for better UX
-    if (!window.confirm('Are you sure you want to delete this item? This action cannot be undone.')) {
+    if (!window.confirm(t('baristaMenu.confirmDelete'))) {
         return;
     }
     try {
         await databases.deleteDocument('cafe', 'item', itemId);
-        toast.add({ title: 'Item Deleted', description: 'The item has been successfully deleted.', color: 'primary', icon: 'i-heroicons-check-circle' });
+        toast.add({ title: t('baristaMenu.toast.itemDeletedTitle'), description: t('baristaMenu.toast.itemDeletedDesc'), color: 'primary', icon: 'i-heroicons-check-circle' });
         await fetchItems(); // Refresh the list
     } catch (error: any) {
         console.error("Failed to delete item:", error);
-        toast.add({ title: 'Deletion Failed', description: error.message || 'Could not delete the item.', color: 'error', icon: 'i-heroicons-x-circle' });
+        toast.add({ title: t('baristaMenu.toast.deletionFailedTitle'), description: error.message || t('baristaMenu.toast.deletionFailedDesc'), color: 'error', icon: 'i-heroicons-x-circle' });
     }
 };
 
@@ -251,7 +253,7 @@ const handleDeleteItem = async (itemId: string): Promise<void> => {
  */
 const handleSaveItem = async (): Promise<void> => {
     if (!currentItemName.value.trim()) {
-        toast.add({ title: 'Validation Error', description: 'Item name is required.', color: 'warning', icon: 'i-heroicons-exclamation-circle' });
+        toast.add({ title: t('baristaMenu.toast.validationErrorTitle'), description: t('baristaMenu.toast.itemNameRequired'), color: 'warning', icon: 'i-heroicons-exclamation-circle' });
         return;
     }
 
@@ -274,16 +276,16 @@ const handleSaveItem = async (): Promise<void> => {
     try {
         if (isEditing.value && currentItemId.value) {
             await databases.updateDocument('cafe', 'item', currentItemId.value, itemData);
-            toast.add({ title: 'Item Updated', description: 'Changes saved successfully.', color: 'primary', icon: 'i-heroicons-check-circle' });
+            toast.add({ title: t('baristaMenu.toast.itemUpdatedTitle'), description: t('baristaMenu.toast.itemUpdatedDesc'), color: 'primary', icon: 'i-heroicons-check-circle' });
         } else {
             await databases.createDocument('cafe', 'item', ID.unique(), itemData);
-            toast.add({ title: 'Item Added', description: 'New item added to the menu.', color: 'primary', icon: 'i-heroicons-check-circle' });
+            toast.add({ title: t('baristaMenu.toast.itemAddedTitle'), description: t('baristaMenu.toast.itemAddedDesc'), color: 'primary', icon: 'i-heroicons-check-circle' });
         }
         await fetchItems();
         showModal.value = false; // Close modal
     } catch (error: any) {
         console.error("Failed to save item:", error);
-        toast.add({ title: 'Save Failed', description: error.message || 'Could not save the item.', color: 'error', icon: 'i-heroicons-x-circle' });
+        toast.add({ title: t('baristaMenu.toast.saveFailedTitle'), description: error.message || t('baristaMenu.toast.saveFailedDesc'), color: 'error', icon: 'i-heroicons-x-circle' });
     }
 };
 
@@ -304,13 +306,16 @@ const parseOption = (optionString: string) => {
             <USkeleton class="h-6 w-1/4" />
         </div>
         <div v-else-if="cafe" class="mb-8">
-            <h1 class="text-4xl font-bold text-coffee">
-                Manage Menu for {{ cafe.name }}
-            </h1>
-            <p class="text-md text-gray-600 dark:text-gray-400">Cafe ID: {{ cafe.$id }}</p>
+            <div class="flex flex-wrap items-start justify-between gap-3">
+                <h1 class="text-4xl font-bold text-coffee">
+                    {{ $t('baristaMenu.manageMenuFor', { cafeName: cafe.name }) }}
+                </h1>
+                <LanguageSwitcher />
+            </div>
+            <p class="text-md text-gray-600 dark:text-gray-400">{{ $t('baristaMenu.cafeId', { id: cafe.$id }) }}</p>
         </div>
 
-        <UButton @click="openAddItemModal" icon="i-heroicons-plus-circle-20-solid" label="Add New Item" class="mb-8 bg-coffee-500 hover:bg-coffee-600 text-white"
+        <UButton @click="openAddItemModal" icon="i-heroicons-plus-circle-20-solid" :label="$t('baristaMenu.addNewItem')" class="mb-8 bg-coffee-500 hover:bg-coffee-600 text-white"
             size="lg" />
 
         <div v-if="isLoadingItems && items.length === 0" class="space-y-4">
@@ -319,8 +324,8 @@ const parseOption = (optionString: string) => {
         <div v-else-if="!items || items.length === 0" class="text-center text-gray-500 dark:text-gray-400 py-12">
             <UIcon name="i-heroicons-clipboard-document-list"
                 class="mx-auto h-16 w-16 text-gray-400 dark:text-gray-500" />
-            <h3 class="mt-4 text-xl font-semibold text-coffee">No items yet</h3>
-            <p class="mt-2 text-md">Get started by adding a new menu item.</p>
+            <h3 class="mt-4 text-xl font-semibold text-coffee">{{ $t('baristaMenu.noItemsTitle') }}</h3>
+            <p class="mt-2 text-md">{{ $t('baristaMenu.noItemsText') }}</p>
         </div>
 
         <ul v-else class="space-y-6">
@@ -340,18 +345,18 @@ const parseOption = (optionString: string) => {
                     <p v-if="item.description" class="text-sm text-gray-600 dark:text-gray-400 my-4">{{ item.description }}</p>
                     <div v-if="item.options && item.options.length > 0">
                         <p class="text-sm font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider mb-2">
-                            Options:</p>
+                            {{ $t('baristaMenu.options') }}</p>
                         <div class="space-y-2">
                             <div v-for="(optionStr, index) in item.options" :key="index" class="text-sm text-gray-700 dark:text-gray-300">
                                 <div v-if="parseOption(optionStr).type === 'boolean'" class="flex items-center gap-2">
                                     <span class="font-medium">{{ parseOption(optionStr).name }}</span>
                                     <span class="text-xs bg-gray-100 dark:bg-gray-800 px-2 py-1 rounded-full border border-gray-200 dark:border-gray-700">
-                                        Yes / No
+                                        {{ $t('baristaMenu.yesNo') }}
                                     </span>
                                 </div>
                                 <div v-else class="flex flex-wrap items-center gap-1.5">
                                     <span class="font-medium mr-1">{{ parseOption(optionStr).name }}:</span>
-                                    <span v-for="val in parseOption(optionStr).values" :key="val" 
+                                    <span v-for="val in parseOption(optionStr).values" :key="val"
                                         class="text-xs bg-latte-100 dark:bg-latte-200 text-coffee px-2 py-1 rounded-md border border-latte-200 dark:border-gray-600">
                                         {{ val }}
                                     </span>
@@ -359,13 +364,13 @@ const parseOption = (optionString: string) => {
                             </div>
                         </div>
                     </div>
-                    <p v-else class="text-sm text-gray-500 dark:text-gray-400 italic">No specific options defined.</p>
+                    <p v-else class="text-sm text-gray-500 dark:text-gray-400 italic">{{ $t('baristaMenu.noOptions') }}</p>
 
                     <template #footer>
                         <div class="flex justify-end space-x-3">
-                            <UButton @click="openEditItemModal(item)" label="Edit"
+                            <UButton @click="openEditItemModal(item)" :label="$t('baristaMenu.edit')"
                                 icon="i-heroicons-pencil-square-20-solid" variant="outline" class="text-coffee border-coffee hover:bg-latte-100" />
-                            <UButton @click="handleDeleteItem(item.$id)" label="Delete"
+                            <UButton @click="handleDeleteItem(item.$id)" :label="$t('baristaMenu.delete')"
                                 icon="i-heroicons-trash-20-solid" color="error" variant="ghost" />
                         </div>
                     </template>
@@ -379,34 +384,34 @@ const parseOption = (optionString: string) => {
             <div class="p-4 flex-1 overflow-y-auto">
                     <div class="flex items-center justify-between mb-4">
                         <h3 class="text-xl font-semibold leading-6 text-coffee">
-                            {{ isEditing ? `Edit ${currentItemName}` : 'Add New Item' }}
+                            {{ isEditing ? $t('baristaMenu.editItemTitle', { name: currentItemName }) : $t('baristaMenu.addItemTitle') }}
                         </h3>
                         <UButton color="neutral" variant="ghost" icon="i-heroicons-x-mark-20-solid"
                             @click="showModal = false" />
                     </div>
                     <div>
                         <div class="flex flex-row">
-                            <UInput v-model="currentItemName" placeholder="e.g., Espresso, Croissant" class="mb-4 mr-4">
+                            <UInput v-model="currentItemName" :placeholder="$t('baristaMenu.itemNamePlaceholder')" class="mb-4 mr-4">
                                 <label class="pointer-events-none absolute left-0 -top-2.5 text-coffee text-xs font-medium px-1.5 transition-all peer-focus:-top-2.5 peer-focus:text-coffee peer-focus:text-xs peer-focus:font-medium peer-placeholder-shown:text-sm peer-placeholder-shown:text-gray-500 peer-placeholder-shown:top-1.5 peer-placeholder-shown:font-normal">
-                                    <span class="inline-flex bg-white dark:bg-latte-50 px-1">Item name</span>
+                                    <span class="inline-flex bg-white dark:bg-latte-50 px-1">{{ $t('baristaMenu.itemNameFloating') }}</span>
                                 </label>
                             </UInput>
-                            <UInput v-model="currentItemPrice" placeholder="e.g., 3.50" class="mb-4">
+                            <UInput v-model="currentItemPrice" :placeholder="$t('baristaMenu.pricePlaceholder')" class="mb-4">
                                 <label class="pointer-events-none absolute left-0 -top-2.5 text-coffee text-xs font-medium px-1.5 transition-all peer-focus:-top-2.5 peer-focus:text-coffee peer-focus:text-xs peer-focus:font-medium peer-placeholder-shown:text-sm peer-placeholder-shown:text-gray-500 peer-placeholder-shown:top-1.5 peer-placeholder-shown:font-normal">
-                                    <span class="inline-flex bg-white dark:bg-latte-50 px-1">Price</span>
+                                    <span class="inline-flex bg-white dark:bg-latte-50 px-1">{{ $t('baristaMenu.priceFloating') }}</span>
                                 </label>
                             </UInput>
                         </div>
                         <div class="mb-4">
-                            <label class="text-coffee text-xs font-medium mb-1 block">Image</label>
+                            <label class="text-coffee text-xs font-medium mb-1 block">{{ $t('baristaMenu.imageLabel') }}</label>
                             <div class="flex items-center gap-3">
-                                <USelect v-model="currentItemImageUrl" :items="allAvailableImages" value-key="value" placeholder="Aucune image" class="flex-1" />
+                                <USelect v-model="currentItemImageUrl" :items="allAvailableImages" value-key="value" :placeholder="$t('baristaMenu.noImage')" class="flex-1" />
                                 <img v-if="currentItemImageUrl" :src="itemImage(currentItemImageUrl, 'thumb')" alt="Preview" loading="lazy" decoding="async" class="w-12 h-12 rounded-md object-cover" />
                             </div>
                         </div>
-                        <UTextarea v-model="currentItemDescription" placeholder="Item description..." class="mb-4" autoresize>
+                        <UTextarea v-model="currentItemDescription" :placeholder="$t('baristaMenu.descriptionPlaceholder')" class="mb-4" autoresize>
                             <label class="pointer-events-none absolute left-0 -top-2.5 text-coffee text-xs font-medium px-1.5 transition-all peer-focus:-top-2.5 peer-focus:text-coffee peer-focus:text-xs peer-focus:font-medium peer-placeholder-shown:text-sm peer-placeholder-shown:text-gray-500 peer-placeholder-shown:top-1.5 peer-placeholder-shown:font-normal">
-                                <span class="inline-flex bg-white dark:bg-latte-50 px-1">Description</span>
+                                <span class="inline-flex bg-white dark:bg-latte-50 px-1">{{ $t('baristaMenu.descriptionFloating') }}</span>
                             </label>
                         </UTextarea>
                     </div>
@@ -414,45 +419,44 @@ const parseOption = (optionString: string) => {
                             <div v-for="(option, index) in currentStructuredOptions" :key="option.id"
                                 class="p-3 border border-gray-200 dark:border-latte-100 rounded-md space-y-3 bg-gray-50 dark:bg-latte-50">
                                 <div class="flex flex-col items-start space-y-2 space-x-2">
-                                        <UInput v-model="option.name" placeholder="e.g., Size, Milk, Decaf" class="w-1/3" required>
+                                        <UInput v-model="option.name" :placeholder="$t('baristaMenu.optionNamePlaceholder')" class="w-1/3" required>
                                             <label class="pointer-events-none absolute left-0 -top-2.5 text-coffee text-xs font-medium px-1.5 transition-all peer-focus:-top-2.5 peer-focus:text-coffee peer-focus:text-xs peer-focus:font-medium peer-placeholder-shown:text-sm peer-placeholder-shown:text-gray-500 peer-placeholder-shown:top-1.5 peer-placeholder-shown:font-normal">
-                                                <span class="inline-flex bg-gray-50 dark:bg-latte-100 px-1">Option name</span>
+                                                <span class="inline-flex bg-gray-50 dark:bg-latte-100 px-1">{{ $t('baristaMenu.optionNameFloating') }}</span>
                                             </label>
                                         </UInput>
-                                        <p class="text-sm font-medium text-gray-700 dark:text-gray-300"> Multiple Values / Simple option</p>
+                                        <p class="text-sm font-medium text-gray-700 dark:text-gray-300"> {{ $t('baristaMenu.multipleValues') }}</p>
                                         <USwitch v-model="option.isBoolean" color="primary"/>
                                     <UButton icon="i-heroicons-x-mark-20-solid" color="error" variant="soft"
                                         @click="removeStructuredOption(index)" class="self-end mb-1.5"
-                                        aria-label="Remove option" />
+                                        :aria-label="$t('baristaMenu.removeOption')" />
                                 </div>
 
                                 <div v-if="Array.isArray(option.values) && !option.isBoolean" class="pl-2 space-y-2">
-                                    <p class="text-sm font-medium text-gray-700 dark:text-gray-300">Values for {{
-                                        option.name || 'this option' }}:</p>
+                                    <p class="text-sm font-medium text-gray-700 dark:text-gray-300">{{ $t('baristaMenu.valuesFor', { name: option.name || $t('baristaMenu.thisOption') }) }}</p>
                                     <div v-for="(valueItem, valueIndex) in option.values" :key="valueItem.id"
                                         class="flex items-center space-x-2">
                                             <UInput v-model="valueItem.name"
-                                                placeholder="e.g., Small, Large, Oat Milk">
+                                                :placeholder="$t('baristaMenu.valuePlaceholder')">
                                                 <label class="pointer-events-none absolute left-0 -top-2.5 text-coffee text-xs font-medium px-1.5 transition-all peer-focus:-top-2.5 peer-focus:text-coffee peer-focus:text-xs peer-focus:font-medium peer-placeholder-shown:text-sm peer-placeholder-shown:text-gray-500 peer-placeholder-shown:top-1.5 peer-placeholder-shown:font-normal">
-                                                    <span class="inline-flex bg-gray-50 dark:bg-latte-100 px-1">Value</span>
+                                                    <span class="inline-flex bg-gray-50 dark:bg-latte-100 px-1">{{ $t('baristaMenu.valueFloating') }}</span>
                                                 </label>
                                             </UInput>
                                         <UButton icon="i-heroicons-minus-circle-20-solid" color="error" variant="link"
                                             @click="removeValueFromOptionList(index, valueIndex)"
-                                            aria-label="Remove value" />
+                                            :aria-label="$t('baristaMenu.removeValue')" />
                                     </div>
                                 </div>
-                                <UButton v-if="!option.isBoolean" label="Add Value" icon="i-heroicons-plus-circle-16-solid" size="xs"
+                                <UButton v-if="!option.isBoolean" :label="$t('baristaMenu.addValue')" icon="i-heroicons-plus-circle-16-solid" size="xs"
                                     variant="outline" @click="addValueToOptionList(index)"
                                     :disabled="!option.name.trim()" />
                             </div>
-                            <UButton label="Add New Option Type" icon="i-heroicons-plus-20-solid" variant="outline"
+                            <UButton :label="$t('baristaMenu.addNewOptionType')" icon="i-heroicons-plus-20-solid" variant="outline"
                                 @click="addNewStructuredOption" />
                         </div>
             </div>
             <div class="p-4 border-t border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-black flex justify-end space-x-3">
-                <UButton label="Cancel" color="neutral" variant="outline" @click="showModal = false" />
-                <UButton type="submit" :label="isEditing ? 'Save Changes' : 'Add Item'"
+                <UButton :label="$t('baristaMenu.cancel')" color="neutral" variant="outline" @click="showModal = false" />
+                <UButton type="submit" :label="isEditing ? $t('baristaMenu.saveChanges') : $t('baristaMenu.addItem')"
                     class="bg-coffee-500 hover:bg-coffee-600 text-white" @click="handleSaveItem" />
             </div>
             </template>
@@ -460,7 +464,7 @@ const parseOption = (optionString: string) => {
 
         <!-- Toaster for notifications -->
         <UNotifications />
-              <UNavigationMenu class="fixed bottom-4 my-4 left-1/2 -translate-x-1/2 flex flex-row justify-between px-2 rounded-lg bg-white dark:bg-latte-50 drop-shadow-md" :items="[{label: 'Orders', to: `/${route.params.cafeId}/barista`}, {label: 'Menu', to: `/${route.params.cafeId}/barista/menu`}, {label: 'Cafe', to: `/${route.params.cafeId}/barista/cafe`}]" />
+              <UNavigationMenu class="fixed bottom-4 my-4 left-1/2 -translate-x-1/2 flex flex-row justify-between px-2 rounded-lg bg-white dark:bg-latte-50 drop-shadow-md" :items="[{label: $t('nav.orders'), to: `/${route.params.cafeId}/barista`}, {label: $t('nav.menu'), to: `/${route.params.cafeId}/barista/menu`}, {label: $t('nav.cafe'), to: `/${route.params.cafeId}/barista/cafe`}]" />
 
     </UContainer>
     </div>

--- a/app/pages/[cafeId]/index.vue
+++ b/app/pages/[cafeId]/index.vue
@@ -10,6 +10,7 @@ const { $appwrite } = useNuxtApp();
 const databases = $appwrite.databases;
 const client = $appwrite.client;
 const toast = useToast();
+const { t } = useI18n();
 
 let itemsPromise = databases.listDocuments("cafe", "item", [
     Query.equal("cafeId", route.params.cafeId as string),
@@ -33,7 +34,7 @@ useHead({
         { name: "viewport", content: "width=device-width,initial-scale=1" },
         {
             name: "description",
-            content: `Order your favorite items from ${cafePromise.name}`,
+            content: t("menu.headDescription", { cafeName: cafePromise.name }),
         },
         { name: "theme-color", content: "#f0e4d2" },
     ],
@@ -130,16 +131,16 @@ async function submitOrder(payload: {
         }
         orders.value.unshift(response);
         toast.add({
-            title: "Order sent",
-            description: "Your order has been sent successfully.",
+            title: t("menu.toast.orderSentTitle"),
+            description: t("menu.toast.orderSentDesc"),
             icon: "i-lucide-check",
             color: "success",
         });
     } catch (error) {
         console.error(error);
         toast.add({
-            title: "Error",
-            description: "Failed to send your order. Please try again.",
+            title: t("menu.toast.errorTitle"),
+            description: t("menu.toast.orderFailDesc"),
             icon: "i-lucide-alert-circle",
             color: "error",
         });
@@ -157,16 +158,16 @@ async function cancelOrder(orderId: string) {
             order.status = "canceled";
         }
         toast.add({
-            title: "Order canceled",
-            description: "Your order has been canceled successfully.",
+            title: t("menu.toast.orderCanceledTitle"),
+            description: t("menu.toast.orderCanceledDesc"),
             icon: "i-lucide-check",
             color: "success",
         });
     } catch (error) {
         console.error(error);
         toast.add({
-            title: "Error",
-            description: "Failed to cancel your order. Please try again.",
+            title: t("menu.toast.errorTitle"),
+            description: t("menu.toast.cancelFailDesc"),
             icon: "i-lucide-alert-circle",
             color: "error",
         });

--- a/app/pages/demo.vue
+++ b/app/pages/demo.vue
@@ -1,84 +1,88 @@
 <script setup lang="ts">
+const { t } = useI18n();
+
 const showSignupPrompt = ref(false);
 
-const demoCafe = { name: "Chez Zola" };
+const demoCafe = computed(() => ({ name: t("demo.cafeName") }));
 
-const demoItems = [
+// Option strings keep the structural "Name:value;value" / "Name:boolean" format the
+// menu component parses; they are sample content rather than translatable UI copy.
+const demoItems = computed(() => [
     {
         $id: "demo-latte",
-        name: "Latte",
-        price: "1 hug 🤗",
-        description: "Silky espresso topped with steamed milk.",
+        name: t("demo.items.latte.name"),
+        price: t("demo.items.latte.price"),
+        description: t("demo.items.latte.description"),
         options: ["Size:small;medium;large", "Milk:cow;oat;almond", "Sugar:boolean"],
         imageUrl: "/images-cafe/latte.png",
     },
     {
         $id: "demo-espresso",
-        name: "Espresso",
-        description: "Short, dark, intense. The classic.",
+        name: t("demo.items.espresso.name"),
+        description: t("demo.items.espresso.description"),
         options: ["Shots:single;double", "Sugar:boolean"],
         imageUrl: "/images-cafe/cafe.png",
     },
     {
         $id: "demo-matcha",
-        name: "Matcha",
+        name: t("demo.items.matcha.name"),
         price: "5€",
-        description: "Whisked ceremonial-grade green tea.",
+        description: t("demo.items.matcha.description"),
         options: ["Size:small;medium", "Milk:none;oat;almond", "Sugar:boolean"],
         imageUrl: "/images-cafe/gaiwan.png",
     },
     {
         $id: "demo-tea",
-        name: "Tea",
-        description: "Loose-leaf, steeped to order.",
+        name: t("demo.items.tea.name"),
+        description: t("demo.items.tea.description"),
         options: ["Blend:earl grey;chamomile;mint;rooibos", "Honey:boolean"],
         imageUrl: "/images-cafe/the.png",
     },
     {
         $id: "demo-juice",
-        name: "Fresh Juice",
-        description: "Pressed this morning.",
+        name: t("demo.items.juice.name"),
+        description: t("demo.items.juice.description"),
         options: ["Flavor:orange;apple;carrot-ginger"],
         imageUrl: "/images-cafe/jus.png",
     },
     {
         $id: "demo-bubble",
-        name: "Bubble Tea",
-        description: "Chewy tapioca, your favorite flavor.",
+        name: t("demo.items.bubble.name"),
+        description: t("demo.items.bubble.description"),
         options: ["Flavor:taro;mango;classic milk", "Ice:boolean"],
         imageUrl: "/images-cafe/bobba.png",
     },
     {
         $id: "demo-muffin",
-        name: "Muffin",
-        description: "Baked this morning.",
+        name: t("demo.items.muffin.name"),
+        description: t("demo.items.muffin.description"),
         options: ["Flavor:chocolate;blueberry;banana"],
         imageUrl: "/images-cafe/muffin.png",
     },
     {
         $id: "demo-cookie",
-        name: "Cookie",
+        name: t("demo.items.cookie.name"),
         price: "📖",
-        description: "Warm and chewy.",
+        description: t("demo.items.cookie.description"),
         options: ["Type:chocolate chip;oatmeal raisin", "Warmed:boolean"],
         imageUrl: "/images-cafe/cookie.png",
     },
     {
         $id: "demo-tartine",
-        name: "Tartine",
-        description: "Sourdough, toasted, with toppings.",
+        name: t("demo.items.tartine.name"),
+        description: t("demo.items.tartine.description"),
         options: ["Topping:butter & jam;avocado;honey & ricotta"],
         imageUrl: "/images-cafe/tartine.png",
     },
     {
         $id: "demo-yogurt",
-        name: "Yogurt",
-        price: "Free!",
-        description: "Greek yogurt, fresh fruits, granola.",
+        name: t("demo.items.yogurt.name"),
+        price: t("demo.items.yogurt.price"),
+        description: t("demo.items.yogurt.description"),
         options: ["Granola:boolean", "Honey:boolean"],
         imageUrl: "/images-cafe/yaourt.png",
     },
-];
+]);
 
 const demoOrders = ref([] as any[]);
 
@@ -95,17 +99,17 @@ function goToSignup() {
     navigateTo("/signup");
 }
 
-useHead({
-    title: demoCafe.name,
+useHead(() => ({
+    title: demoCafe.value.name,
     meta: [
         { name: "viewport", content: "width=device-width,initial-scale=1" },
         {
             name: "description",
-            content: `Order your favorite items from ${demoCafe.name}`,
+            content: t("menu.headDescription", { cafeName: demoCafe.value.name }),
         },
         { name: "theme-color", content: "#f0e4d2" },
     ],
-});
+}));
 </script>
 
 <template>
@@ -120,20 +124,19 @@ useHead({
             <div class="p-6 sm:p-8 text-center">
                 <div class="text-5xl mb-4">☕</div>
                 <h2 class="font-serif font-bold text-2xl text-coffee mb-3">
-                    Want your own home café?
+                    {{ $t('demo.promptTitle') }}
                 </h2>
                 <p class="text-coffee-600 mb-6 leading-relaxed">
-                    If you'd love to open your own tiny café for friends and family,
-                    sign up — it's totally free, ad-free, and takes about a minute.
+                    {{ $t('demo.promptText') }}
                 </p>
                 <div class="flex flex-col sm:flex-row-reverse gap-3 sm:justify-center">
                     <UButton size="lg" block @click="goToSignup"
                         class="bg-coffee-500 hover:bg-coffee-600 text-white rounded-full justify-center">
-                        Open my tiny café
+                        {{ $t('demo.openCafe') }}
                     </UButton>
                     <UButton size="lg" block color="neutral" variant="ghost" @click="showSignupPrompt = false"
                         class="text-coffee hover:bg-latte-100 justify-center">
-                        Keep browsing
+                        {{ $t('demo.keepBrowsing') }}
                     </UButton>
                 </div>
             </div>

--- a/app/pages/index.vue
+++ b/app/pages/index.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="min-h-screen bg-latte text-gray-700 font-sans selection:bg-latte-200 selection:text-coffee">
-    
+
     <!-- Navbar -->
     <nav class="flex items-center justify-between px-6 py-4 max-w-7xl mx-auto">
       <div class="text-xl font-bold text-coffee flex items-center gap-2">
@@ -8,18 +8,19 @@
         <span>My Tiny Café</span>
       </div>
       <div class="flex items-center gap-4">
-        <UButton 
-          to="/login" 
-          variant="ghost" 
-          color="neutral" 
-          label="Login" 
+        <LanguageSwitcher />
+        <UButton
+          to="/login"
+          variant="ghost"
+          color="neutral"
+          :label="$t('landing.nav.login')"
           class="hidden sm:flex hover:bg-latte-100"
         />
-        <UButton 
-          to="/signup" 
-          color="primary" 
-          variant="solid" 
-          label="Open My Tiny Café" 
+        <UButton
+          to="/signup"
+          color="primary"
+          variant="solid"
+          :label="$t('landing.nav.openCafe')"
           class="bg-coffee-500 hover:bg-coffee-600 text-white transition-colors duration-300"
         />
       </div>
@@ -31,13 +32,13 @@
         <div class="grid lg:grid-cols-2 gap-12 items-center">
           <!-- Text Content -->
           <div class="text-center lg:text-left space-y-8">
-            <h1 class="text-5xl lg:text-7xl font-serif font-bold text-coffee leading-tight">
-              Turn Your Home into the <span class="text-coffee-500">Best Coffee Shop</span> in Town.
-            </h1>
+            <i18n-t keypath="landing.hero.title" tag="h1" class="text-5xl lg:text-7xl font-serif font-bold text-coffee leading-tight">
+              <template #highlight><span class="text-coffee-500">{{ $t('landing.hero.titleHighlight') }}</span></template>
+            </i18n-t>
             <p class="text-xl text-gray-600 dark:text-gray-400 leading-relaxed max-w-2xl mx-auto lg:mx-0">
-              The digital menu for home baristas. Create your drink list, share your QR code with friends and family, and receive orders straight to your phone. 
+              {{ $t('landing.hero.subtitle') }}
               <br class="hidden lg:block" />
-              <span class="font-semibold text-coffee-500">100% Free. 100% Cozy.</span>
+              <span class="font-semibold text-coffee-500">{{ $t('landing.hero.subtitleEmphasis') }}</span>
             </p>
             <div class="flex flex-col sm:flex-row gap-4 justify-center lg:justify-start">
               <UButton
@@ -45,7 +46,7 @@
                 size="xl"
                 class="bg-coffee-500 hover:bg-coffee-600 text-white px-8 py-4 rounded-full shadow-lg hover:shadow-xl transition-all transform hover:-translate-y-1 justify-center"
               >
-                Open My Tiny Café
+                {{ $t('landing.hero.ctaPrimary') }}
               </UButton>
               <UButton
                 to="/demo"
@@ -54,11 +55,11 @@
                 color="neutral"
                 class="text-coffee-500 hover:bg-latte-100 px-8 py-4 rounded-full justify-center"
               >
-                See a demo café ↗
+                {{ $t('landing.hero.ctaDemo') }}
               </UButton>
             </div>
             <p class="text-sm text-gray-500 dark:text-gray-400 italic">
-              No credit card required. No ads. Just love.
+              {{ $t('landing.hero.noCreditCard') }}
             </p>
           </div>
 
@@ -79,23 +80,23 @@
                                 <UIcon name="i-heroicons-cup-saucer" class="w-5 h-5 text-white" />
                             </div>
                             <div>
-                                <p class="text-xs font-semibold text-coffee">New Order from Magali</p>
-                                <p class="text-xs text-gray-600">Latte (Oat Milk, No Sugar)</p>
+                                <p class="text-xs font-semibold text-coffee">{{ $t('landing.mockup.notifTitle') }}</p>
+                                <p class="text-xs text-gray-600">{{ $t('landing.mockup.notifOrder') }}</p>
                             </div>
-                            <span class="text-[10px] text-gray-400 ml-auto">now</span>
+                            <span class="text-[10px] text-gray-400 ml-auto">{{ $t('landing.mockup.now') }}</span>
                         </div>
 
                         <!-- App Content Mock -->
                         <div class="p-4 mt-4">
-                            <h3 class="font-serif text-xl text-coffee font-bold mb-3 ml-1">Menu</h3>
+                            <h3 class="font-serif text-xl text-coffee font-bold mb-3 ml-1">{{ $t('landing.mockup.menu') }}</h3>
                             <div class="grid grid-cols-2 gap-2">
                                 <div class="border-2 border-coffee-500 overflow-hidden bg-white dark:bg-latte-50 flex flex-col">
                                     <div class="aspect-square w-full bg-latte-100">
                                         <img src="/images-cafe/latte-400.webp" alt="Latte" width="140" height="140" loading="lazy" decoding="async" class="w-full h-full object-cover" />
                                     </div>
                                     <div class="flex items-center justify-between gap-1 px-2 py-1 border-t-2 border-coffee-500">
-                                        <div class="font-medium text-coffee text-xs truncate">Latte</div>
-                                        <div class="text-coffee-600 text-[10px] shrink-0">1 hug 🤗</div>
+                                        <div class="font-medium text-coffee text-xs truncate">{{ $t('landing.mockup.latte') }}</div>
+                                        <div class="text-coffee-600 text-[10px] shrink-0">{{ $t('landing.mockup.lattePrice') }}</div>
                                     </div>
                                 </div>
                                 <div class="border-2 border-coffee-500 overflow-hidden bg-white dark:bg-latte-50 flex flex-col">
@@ -103,7 +104,7 @@
                                         <img src="/images-cafe/gaiwan-400.webp" alt="Matcha" width="140" height="140" loading="lazy" decoding="async" class="w-full h-full object-cover" />
                                     </div>
                                     <div class="flex items-center justify-between gap-1 px-2 py-1 border-t-2 border-coffee-500">
-                                        <div class="font-medium text-coffee text-xs truncate">Matcha</div>
+                                        <div class="font-medium text-coffee text-xs truncate">{{ $t('landing.mockup.matcha') }}</div>
                                         <div class="text-coffee-600 text-[10px] shrink-0">5€</div>
                                     </div>
                                 </div>
@@ -112,8 +113,8 @@
                                         <img src="/images-cafe/the-400.webp" alt="Tea" width="140" height="140" loading="lazy" decoding="async" class="w-full h-full object-cover" />
                                     </div>
                                     <div class="flex items-center justify-between gap-1 px-2 py-1 border-t-2 border-coffee-500">
-                                        <div class="font-medium text-coffee text-xs truncate">Tea</div>
-                                        <div class="text-coffee-600 text-[10px] shrink-0">A story 📖</div>
+                                        <div class="font-medium text-coffee text-xs truncate">{{ $t('landing.mockup.tea') }}</div>
+                                        <div class="text-coffee-600 text-[10px] shrink-0">{{ $t('landing.mockup.teaPrice') }}</div>
                                     </div>
                                 </div>
                                 <div class="border-2 border-coffee-500 overflow-hidden bg-white dark:bg-latte-50 flex flex-col">
@@ -121,8 +122,8 @@
                                         <img src="/images-cafe/cookie-400.webp" alt="Cookie" width="140" height="140" loading="lazy" decoding="async" class="w-full h-full object-cover" />
                                     </div>
                                     <div class="flex items-center justify-between gap-1 px-2 py-1 border-t-2 border-coffee-500">
-                                        <div class="font-medium text-coffee text-xs truncate">Cookie</div>
-                                        <div class="text-coffee-600 text-[10px] shrink-0">Free!</div>
+                                        <div class="font-medium text-coffee text-xs truncate">{{ $t('landing.mockup.cookie') }}</div>
+                                        <div class="text-coffee-600 text-[10px] shrink-0">{{ $t('landing.mockup.cookiePrice') }}</div>
                                     </div>
                                 </div>
                             </div>
@@ -142,25 +143,25 @@
     <section class="py-20 bg-white dark:bg-latte-50">
       <div class="max-w-4xl mx-auto px-6 text-center space-y-12">
         <div class="space-y-4">
-          <h2 class="text-sm font-bold tracking-widest text-coffee-500 uppercase">Hospitality, Upgraded</h2>
+          <h2 class="text-sm font-bold tracking-widest text-coffee-500 uppercase">{{ $t('landing.valueProp.eyebrow') }}</h2>
           <h3 class="text-3xl lg:text-4xl font-serif font-bold text-coffee">
-            Why shout from the kitchen?
+            {{ $t('landing.valueProp.heading') }}
           </h3>
         </div>
-        
+
         <div class="grid md:grid-cols-2 gap-12 items-start">
             <div class="bg-latte-50 p-8 rounded-3xl h-full">
                 <div class="text-4xl mb-4">😫</div>
-                <h4 class="font-bold text-lg mb-2 text-coffee">The Problem</h4>
+                <h4 class="font-bold text-lg mb-2 text-coffee">{{ $t('landing.valueProp.problemTitle') }}</h4>
                 <p class="text-gray-600 dark:text-gray-400">
-                    Shouting from the kitchen, "Who wants tea?" and forgetting who wanted sugar and who wanted almond milk by the time the kettle boils.
+                    {{ $t('landing.valueProp.problemText') }}
                 </p>
             </div>
             <div class="bg-green-soft p-8 rounded-3xl h-full">
                 <div class="text-4xl mb-4">✨</div>
-                <h4 class="font-bold text-lg mb-2 text-coffee">The Solution</h4>
+                <h4 class="font-bold text-lg mb-2 text-coffee">{{ $t('landing.valueProp.solutionTitle') }}</h4>
                 <p class="text-gray-600 dark:text-gray-400">
-                    My Tiny Café brings the delight of a boutique coffee shop experience to your living room. Make the moment special.
+                    {{ $t('landing.valueProp.solutionText') }}
                 </p>
             </div>
         </div>
@@ -171,18 +172,18 @@
     <section class="py-20 bg-latte">
       <div class="max-w-7xl mx-auto px-6">
         <h2 class="text-3xl lg:text-4xl font-serif font-bold text-center text-coffee mb-16">
-          How It Works (3 Simple Steps)
+          {{ $t('landing.howItWorks.title') }}
         </h2>
-        
+
         <div class="grid md:grid-cols-3 gap-12">
           <!-- Step 1 -->
           <div class="text-center space-y-4">
             <div class="w-16 h-16 bg-coffee-500 text-white rounded-2xl flex items-center justify-center mx-auto shadow-lg rotate-3">
               <UIcon name="i-heroicons-clipboard-document-list" class="w-8 h-8" />
             </div>
-            <h3 class="text-xl font-bold text-coffee">1. Build Your Menu</h3>
+            <h3 class="text-xl font-bold text-coffee">{{ $t('landing.howItWorks.step1Title') }}</h3>
             <p class="text-gray-600 dark:text-gray-400">
-              Give your café a name. Add your specialties—Latte, Tisane, or Tartine. Customize options for milk and sugar.
+              {{ $t('landing.howItWorks.step1Text') }}
             </p>
           </div>
 
@@ -191,9 +192,9 @@
             <div class="w-16 h-16 bg-coffee-500 text-white rounded-2xl flex items-center justify-center mx-auto shadow-lg -rotate-3">
               <UIcon name="i-heroicons-qr-code" class="w-8 h-8" />
             </div>
-            <h3 class="text-xl font-bold text-coffee">2. Share the Link</h3>
+            <h3 class="text-xl font-bold text-coffee">{{ $t('landing.howItWorks.step2Title') }}</h3>
             <p class="text-gray-600 dark:text-gray-400">
-              Print your QR code for the fridge or text the link. Guests browse and customize their beverage exactly how they like it.
+              {{ $t('landing.howItWorks.step2Text') }}
             </p>
           </div>
 
@@ -202,9 +203,9 @@
             <div class="w-16 h-16 bg-coffee-500 text-white rounded-2xl flex items-center justify-center mx-auto shadow-lg rotate-3">
               <UIcon name="i-heroicons-bell-alert" class="w-8 h-8" />
             </div>
-            <h3 class="text-xl font-bold text-coffee">3. Get Notified & Serve</h3>
+            <h3 class="text-xl font-bold text-coffee">{{ $t('landing.howItWorks.step3Title') }}</h3>
             <p class="text-gray-600 dark:text-gray-400">
-              Ding! You get a notification instantly. No money changes hands—just a perfect cup served with a smile.
+              {{ $t('landing.howItWorks.step3Text') }}
             </p>
           </div>
         </div>
@@ -215,34 +216,34 @@
     <section class="py-20 bg-white dark:bg-latte-50">
       <div class="max-w-5xl mx-auto px-6">
         <div class="bg-coffee dark:bg-latte-100 rounded-[3rem] p-8 lg:p-16 text-white shadow-2xl">
-            <h2 class="text-3xl font-serif font-bold mb-12 text-center">Features</h2>
+            <h2 class="text-3xl font-serif font-bold mb-12 text-center">{{ $t('landing.features.title') }}</h2>
             <div class="grid md:grid-cols-2 gap-x-12 gap-y-8">
                 <div class="flex gap-4">
                     <UIcon name="i-lucide-coffee" class="w-6 h-6 text-green-pale shrink-0" />
                     <div>
-                        <h4 class="font-bold text-lg mb-1">Fully Customizable Menu</h4>
-                        <p class="text-gray-300 text-sm">From "Tisane d'allaitement" to "Iced Matcha", you define what you serve.</p>
+                        <h4 class="font-bold text-lg mb-1">{{ $t('landing.features.feature1Title') }}</h4>
+                        <p class="text-gray-300 text-sm">{{ $t('landing.features.feature1Text') }}</p>
                     </div>
                 </div>
                 <div class="flex gap-4">
                     <UIcon name="i-heroicons-device-phone-mobile" class="w-6 h-6 text-green-pale shrink-0" />
                     <div>
-                        <h4 class="font-bold text-lg mb-1">Instant Push Notifications</h4>
-                        <p class="text-gray-300 text-sm">Never miss an order. You’ll know the second your "customer" submits their request.</p>
+                        <h4 class="font-bold text-lg mb-1">{{ $t('landing.features.feature2Title') }}</h4>
+                        <p class="text-gray-300 text-sm">{{ $t('landing.features.feature2Text') }}</p>
                     </div>
                 </div>
                 <div class="flex gap-4">
                     <UIcon name="i-heroicons-arrow-down-tray" class="w-6 h-6 text-green-pale shrink-0" />
                     <div>
-                        <h4 class="font-bold text-lg mb-1">Zero App Download</h4>
-                        <p class="text-gray-300 text-sm">Guests just scan (or click) and order. No installation needed.</p>
+                        <h4 class="font-bold text-lg mb-1">{{ $t('landing.features.feature3Title') }}</h4>
+                        <p class="text-gray-300 text-sm">{{ $t('landing.features.feature3Text') }}</p>
                     </div>
                 </div>
                 <div class="flex gap-4">
                     <UIcon name="i-heroicons-heart" class="w-6 h-6 text-green-pale shrink-0" />
                     <div>
-                        <h4 class="font-bold text-lg mb-1">Totally Free</h4>
-                        <p class="text-gray-300 text-sm">No payment gateways. The only currency here is gratitude.</p>
+                        <h4 class="font-bold text-lg mb-1">{{ $t('landing.features.feature4Title') }}</h4>
+                        <p class="text-gray-300 text-sm">{{ $t('landing.features.feature4Text') }}</p>
                     </div>
                 </div>
             </div>
@@ -253,31 +254,31 @@
     <!-- Real Stories -->
     <section class="py-20 bg-latte">
       <div class="max-w-4xl mx-auto px-6">
-        <h2 class="text-3xl font-serif font-bold text-center text-coffee mb-16">Real Stories</h2>
+        <h2 class="text-3xl font-serif font-bold text-center text-coffee mb-16">{{ $t('landing.stories.title') }}</h2>
         <div class="grid md:grid-cols-2 gap-8">
             <div class="bg-white dark:bg-latte-50 p-8 rounded-2xl shadow-sm border border-gray-100 dark:border-gray-700 relative">
                 <div class="text-6xl text-latte-100 absolute top-4 left-4 font-serif">"</div>
                 <p class="text-gray-700 dark:text-gray-300 relative z-10 italic mb-4">
-                    Can I use your app to order a tea, dad?
+                    {{ $t('landing.stories.quote1') }}
                 </p>
                 <div class="flex items-center gap-3">
                     <div class="w-10 h-10 bg-pink-100 rounded-full flex items-center justify-center text-xl">👧</div>
                     <div>
-                        <p class="font-bold text-sm text-coffee">Zola, Age 5</p>
-                        <p class="text-xs text-gray-500">Chief Taste Tester</p>
+                        <p class="font-bold text-sm text-coffee">{{ $t('landing.stories.quote1Name') }}</p>
+                        <p class="text-xs text-gray-500">{{ $t('landing.stories.quote1Role') }}</p>
                     </div>
                 </div>
             </div>
             <div class="bg-white dark:bg-latte-50 p-8 rounded-2xl shadow-sm border border-gray-100 dark:border-gray-700 relative">
                 <div class="text-6xl text-latte-100 absolute top-4 left-4 font-serif">"</div>
                 <p class="text-gray-700 dark:text-gray-300 relative z-10 italic mb-4">
-                    It's so much easier to order a coffee for when I get back home. And the barista is super cute too!
+                    {{ $t('landing.stories.quote2') }}
                 </p>
                 <div class="flex items-center gap-3">
                     <div class="w-10 h-10 bg-blue-100 rounded-full flex items-center justify-center text-xl">👩</div>
                     <div>
-                        <p class="font-bold text-sm text-coffee">Magali</p>
-                        <p class="text-xs text-gray-500">Wife & Loyal Customer</p>
+                        <p class="font-bold text-sm text-coffee">{{ $t('landing.stories.quote2Name') }}</p>
+                        <p class="text-xs text-gray-500">{{ $t('landing.stories.quote2Role') }}</p>
                     </div>
                 </div>
             </div>
@@ -288,22 +289,22 @@
     <!-- Who is it for -->
     <section class="py-20 bg-white dark:bg-latte-50">
       <div class="max-w-6xl mx-auto px-6">
-        <h2 class="text-3xl font-serif font-bold text-center text-coffee mb-16">Who is My Tiny Café For?</h2>
+        <h2 class="text-3xl font-serif font-bold text-center text-coffee mb-16">{{ $t('landing.audience.title') }}</h2>
         <div class="grid md:grid-cols-3 gap-8">
             <div class="text-center p-6">
                 <div class="text-5xl mb-4">💻</div>
-                <h3 class="font-bold text-lg mb-2">The Remote Work Power Couple</h3>
-                <p class="text-sm text-gray-600 dark:text-gray-400">Send a silent order for a caffeine boost without interrupting the Zoom meeting.</p>
+                <h3 class="font-bold text-lg mb-2">{{ $t('landing.audience.card1Title') }}</h3>
+                <p class="text-sm text-gray-600 dark:text-gray-400">{{ $t('landing.audience.card1Text') }}</p>
             </div>
             <div class="text-center p-6">
                 <div class="text-5xl mb-4">🍽️</div>
-                <h3 class="font-bold text-lg mb-2">The "Host with the Most"</h3>
-                <p class="text-sm text-gray-600 dark:text-gray-400">Impress your guests by letting them order their post-meal digestif via a digital menu.</p>
+                <h3 class="font-bold text-lg mb-2">{{ $t('landing.audience.card2Title') }}</h3>
+                <p class="text-sm text-gray-600 dark:text-gray-400">{{ $t('landing.audience.card2Text') }}</p>
             </div>
             <div class="text-center p-6">
                 <div class="text-5xl mb-4">🧸</div>
-                <h3 class="font-bold text-lg mb-2">The Playful Parent</h3>
-                <p class="text-sm text-gray-600 dark:text-gray-400">Kids love playing "restaurant." Set up the menu for them and let them take your order.</p>
+                <h3 class="font-bold text-lg mb-2">{{ $t('landing.audience.card3Title') }}</h3>
+                <p class="text-sm text-gray-600 dark:text-gray-400">{{ $t('landing.audience.card3Text') }}</p>
             </div>
         </div>
       </div>
@@ -312,25 +313,25 @@
     <!-- FAQ -->
     <section class="py-20 bg-latte">
       <div class="max-w-3xl mx-auto px-6">
-        <h2 class="text-3xl font-serif font-bold text-center text-coffee mb-12">FAQ</h2>
+        <h2 class="text-3xl font-serif font-bold text-center text-coffee mb-12">{{ $t('landing.faq.title') }}</h2>
         <div class="space-y-6">
             <UCard>
                 <template #header>
-                    <h3 class="font-bold text-coffee">Is it really free?</h3>
+                    <h3 class="font-bold text-coffee">{{ $t('landing.faq.q1') }}</h3>
                 </template>
-                <p class="text-gray-600 dark:text-gray-400 text-sm">Yes! My Tiny Café is currently completely free to use.</p>
+                <p class="text-gray-600 dark:text-gray-400 text-sm">{{ $t('landing.faq.a1') }}</p>
             </UCard>
             <UCard>
                 <template #header>
-                    <h3 class="font-bold text-coffee">Can I charge money for the drinks?</h3>
+                    <h3 class="font-bold text-coffee">{{ $t('landing.faq.q2') }}</h3>
                 </template>
-                <p class="text-gray-600 dark:text-gray-400 text-sm">No. This app is designed for friends and family. There is no payment processing involved—just the joy of serving a drink to someone you care about.</p>
+                <p class="text-gray-600 dark:text-gray-400 text-sm">{{ $t('landing.faq.a2') }}</p>
             </UCard>
             <UCard>
                 <template #header>
-                    <h3 class="font-bold text-coffee">What can I put on the menu?</h3>
+                    <h3 class="font-bold text-coffee">{{ $t('landing.faq.q3') }}</h3>
                 </template>
-                <p class="text-gray-600 dark:text-gray-400 text-sm">Anything! Coffee, tea, snacks, tartines, water... if you can make it in your kitchen, you can put it on your menu.</p>
+                <p class="text-gray-600 dark:text-gray-400 text-sm">{{ $t('landing.faq.a3') }}</p>
             </UCard>
         </div>
       </div>
@@ -342,19 +343,19 @@
         <div class="inline-flex items-center justify-center p-4 bg-gray-900 rounded-full shadow-lg mb-4">
             <UIcon name="i-simple-icons-github" class="w-8 h-8 text-white" />
         </div>
-        <h2 class="text-3xl font-serif font-bold text-coffee">Proudly Open Source</h2>
+        <h2 class="text-3xl font-serif font-bold text-coffee">{{ $t('landing.openSource.title') }}</h2>
         <p class="text-gray-600 dark:text-gray-400 max-w-2xl mx-auto">
-            I believe in transparency and community. My Tiny Café is open source, so you can see exactly how it's built, contribute features, or host it yourself.
+            {{ $t('landing.openSource.text') }}
         </p>
-        <UButton 
-            to="https://github.com/Karalix/micro-cafe" 
+        <UButton
+            to="https://github.com/Karalix/micro-cafe"
             target="_blank"
-            variant="solid" 
+            variant="solid"
             size="xl"
             class="bg-gray-900 hover:bg-gray-800 text-white"
         >
             <UIcon name="i-simple-icons-github" class="w-5 h-5 mr-2" />
-            View on GitHub
+            {{ $t('landing.openSource.button') }}
         </UButton>
       </div>
     </section>
@@ -362,28 +363,28 @@
     <!-- Footer -->
     <footer class="bg-coffee text-latte-100 py-20">
         <div class="max-w-4xl mx-auto px-6 text-center space-y-8">
-            <h2 class="text-3xl lg:text-4xl font-serif font-bold">Ready to open shop?</h2>
-            <p class="text-xl opacity-90">Join the community of home baristas today.</p>
-            
-            <UButton 
-                to="/signup" 
+            <h2 class="text-3xl lg:text-4xl font-serif font-bold">{{ $t('landing.footer.title') }}</h2>
+            <p class="text-xl opacity-90">{{ $t('landing.footer.subtitle') }}</p>
+
+            <UButton
+                to="/signup"
                 size="xl"
                 class="bg-latte-100 hover:bg-white dark:hover:bg-latte-200 text-coffee px-8 py-4 rounded-full font-bold"
             >
-                Create Your Café Now
+                {{ $t('landing.footer.cta') }}
             </UButton>
 
             <div class="pt-12 border-t border-latte-100/20 mt-12 text-sm opacity-60 space-y-2">
-                <p>Made with ❤️ in France for Zola and Magali.</p>
-                <p>© 2024 My Tiny Café</p>
+                <p>{{ $t('landing.footer.madeWith') }}</p>
+                <p>{{ $t('landing.footer.copyright') }}</p>
                 <div class="pt-4">
-                    <a href="https://krlx.fr" target="_blank" rel="noopener noreferrer"><h4 class="font-bold uppercase tracking-widest text-xs mb-2">About the Maker</h4></a>
-                    <p class="max-w-md mx-auto">
-                        I am Alix, I built this to make my wife and daughter happy. I hope it brings a little joy to your home too. I am a freelance frontend developer (preferably in Vue.js / Nuxt.js) with a background in Human-Computer Interaction research. <a href="https://krlx.fr" target="_blank" rel="noopener noreferrer" class="underline">Check out my work</a>.
-                    </p>
+                    <a href="https://krlx.fr" target="_blank" rel="noopener noreferrer"><h4 class="font-bold uppercase tracking-widest text-xs mb-2">{{ $t('landing.footer.aboutMakerTitle') }}</h4></a>
+                    <i18n-t keypath="landing.footer.aboutMakerText" tag="p" class="max-w-md mx-auto">
+                        <template #link><a href="https://krlx.fr" target="_blank" rel="noopener noreferrer" class="underline">{{ $t('landing.footer.aboutMakerLink') }}</a></template>
+                    </i18n-t>
                 </div>
                 <div class="pt-8">
-                    <p class="text-xs">Guest? <UButton to="/invalid-cafe" variant="link" color="neutral" class="text-latte-100 underline p-0">Find a Café</UButton></p>
+                    <p class="text-xs">{{ $t('landing.footer.guest') }} <UButton to="/invalid-cafe" variant="link" color="neutral" class="text-latte-100 underline p-0">{{ $t('landing.footer.findCafe') }}</UButton></p>
                 </div>
             </div>
         </div>

--- a/app/pages/invalid-cafe.vue
+++ b/app/pages/invalid-cafe.vue
@@ -8,34 +8,34 @@
 
             <div class="space-y-3">
                 <h1 class="text-4xl sm:text-5xl font-serif font-bold text-coffee leading-tight">
-                    This café is closed.
+                    {{ $t('invalidCafe.title') }}
                 </h1>
-                <p class="text-lg text-gray-600 dark:text-gray-400">
-                    We couldn't find any café at this address. Maybe the link is wrong — or maybe it's time for
-                    <span class="text-coffee-500 font-semibold">you</span> to open your own?
-                </p>
+                <i18n-t keypath="invalidCafe.text" tag="p" class="text-lg text-gray-600 dark:text-gray-400">
+                    <template #you><span class="text-coffee-500 font-semibold">{{ $t('invalidCafe.textHighlight') }}</span></template>
+                </i18n-t>
             </div>
 
             <div class="flex flex-col sm:flex-row gap-3 justify-center pt-2">
                 <UButton to="/signup" size="xl"
                     class="bg-coffee-500 hover:bg-coffee-600 text-white px-8 rounded-full shadow-lg hover:shadow-xl transition-all transform hover:-translate-y-0.5 justify-center">
-                    Open my own café
+                    {{ $t('invalidCafe.openOwn') }}
                 </UButton>
                 <UButton to="/" size="xl" variant="ghost" color="neutral"
                     class="text-coffee hover:bg-latte-100 px-8 rounded-full justify-center">
-                    Back home
+                    {{ $t('invalidCafe.backHome') }}
                 </UButton>
             </div>
 
             <p class="text-sm text-gray-500 dark:text-gray-400 italic pt-4">
-                No credit card. No ads. Just love.
+                {{ $t('invalidCafe.noCreditCard') }}
             </p>
         </div>
     </div>
 </template>
 
 <script setup lang="ts">
+const { t } = useI18n();
 useHead({
-    title: "Café not found — My Tiny Café",
+    title: t('invalidCafe.headTitle'),
 });
 </script>

--- a/app/pages/login.vue
+++ b/app/pages/login.vue
@@ -3,25 +3,28 @@
   <div class="bg-latte min-h-screen flex items-center justify-center p-4">
     <UCard class="w-full max-w-sm bg-white dark:bg-latte-50 ring-1 ring-gray-200 dark:ring-gray-700">
       <template #header>
-        <h2 class="text-xl font-semibold text-center text-coffee">Login</h2>
+        <div class="flex items-center justify-between gap-2">
+          <h2 class="text-xl font-semibold text-coffee">{{ $t('auth.login.title') }}</h2>
+          <LanguageSwitcher />
+        </div>
       </template>
 
       <UForm :state="state" :schema="schema" @submit="handleLogin" class="flex flex-col space-y-4">
-        <UFormGroup label="Email" name="email" class="mb-4">
+        <UFormGroup :label="$t('auth.fields.emailLabel')" name="email" class="mb-4">
           <UInput
             v-model="state.email"
             type="email"
-            placeholder="you@example.com"
+            :placeholder="$t('auth.fields.emailPlaceholder')"
             icon="i-heroicons-envelope"
             required
           >
             <label class="pointer-events-none absolute left-0 -top-2.5 text-coffee text-xs font-medium px-1.5 transition-all peer-focus:-top-2.5 peer-focus:text-coffee peer-focus:text-xs peer-focus:font-medium peer-placeholder-shown:text-sm peer-placeholder-shown:text-gray-500 peer-placeholder-shown:top-1.5 peer-placeholder-shown:font-normal">
-              <span class="inline-flex bg-white dark:bg-latte-50 px-1">Email</span>
+              <span class="inline-flex bg-white dark:bg-latte-50 px-1">{{ $t('auth.fields.emailFloating') }}</span>
             </label>
-          </UInput> 
+          </UInput>
         </UFormGroup>
 
-        <UFormGroup label="Password" name="password" class="mb-6">
+        <UFormGroup :label="$t('auth.fields.passwordLabel')" name="password" class="mb-6">
           <UInput
             v-model="state.password"
             type="password"
@@ -30,9 +33,9 @@
             required
           >
             <label class="pointer-events-none absolute left-0 -top-2.5 text-coffee text-xs font-medium px-1.5 transition-all peer-focus:-top-2.5 peer-focus:text-coffee peer-focus:text-xs peer-focus:font-medium peer-placeholder-shown:text-sm peer-placeholder-shown:text-gray-500 peer-placeholder-shown:top-1.5 peer-placeholder-shown:font-normal">
-              <span class="inline-flex bg-white dark:bg-latte-50 px-1">Password</span>
+              <span class="inline-flex bg-white dark:bg-latte-50 px-1">{{ $t('auth.fields.passwordFloating') }}</span>
             </label>
-          </UInput> 
+          </UInput>
         </UFormGroup>
 
         <UAlert
@@ -46,7 +49,7 @@
 
         <UButton
           type="submit"
-          label="Login"
+          :label="$t('auth.login.submit')"
           block
           :loading="loading"
           :disabled="loading"
@@ -56,8 +59,8 @@
 
       <template #footer>
         <p class="text-sm text-center text-gray-500">
-          Don't have an account?
-          <NuxtLink to="/signup" class="text-coffee-600 font-medium hover:underline">Sign up</NuxtLink>
+          {{ $t('auth.login.noAccount') }}
+          <NuxtLink to="/signup" class="text-coffee-600 font-medium hover:underline">{{ $t('auth.login.signupLink') }}</NuxtLink>
         </p>
       </template>
     </UCard>
@@ -73,6 +76,7 @@ const { $appwrite } = useNuxtApp();
 const account = $appwrite.account;
 const router = useRouter();
 const { add: addToast } = useToast(); // Optional: For success/error notifications
+const { t } = useI18n();
 
 const loading = ref<boolean>(false);
 const errorMessage = ref<string | null>(null);
@@ -85,8 +89,8 @@ const state = reactive({
 
 // Define Zod schema for validation
 const schema = z.object({
-  email: z.string().email('Invalid email address'),
-  password: z.string().min(8, 'Password must be at least 8 characters'),
+  email: z.string().email(t('auth.validation.invalidEmail')),
+  password: z.string().min(8, t('auth.validation.passwordMin')),
 });
 
 type Schema = z.output<typeof schema>
@@ -109,7 +113,7 @@ async function handleLogin(event: FormSubmitEvent<Schema>) {
     await account.createEmailPasswordSession(email, password);
 
     console.log('Login successful'); // Debug log
-    addToast({ title: 'Login Successful!', description: 'Redirecting...', color: 'success' });
+    addToast({ title: t('auth.login.successTitle'), description: t('auth.login.successDesc'), color: 'success' });
 
     // Get cafeID from preferences
     const preferences = await account.getPrefs();
@@ -126,8 +130,8 @@ async function handleLogin(event: FormSubmitEvent<Schema>) {
       await router.push(`/${cafeID}/barista`); // Adjust the redirect path as needed
     }
     console.error('Login failed:', error); // Debug log
-    errorMessage.value = error.message || 'An unexpected error occurred. Please try again.';
-    addToast({ title: 'Login Failed', description: errorMessage.value!, color: 'error' });
+    errorMessage.value = error.message || t('auth.login.errorUnexpected');
+    addToast({ title: t('auth.login.failTitle'), description: errorMessage.value!, color: 'error' });
   } finally {
     loading.value = false;
   }

--- a/app/pages/pwa.vue
+++ b/app/pages/pwa.vue
@@ -17,7 +17,7 @@ if (lastVisitedCafe) {
         <div class="animate-bounce mb-6">
             <UIcon name="i-lucide-coffee" class="w-20 h-20 text-coffee-500" />
         </div>
-        <h2 class="text-2xl font-bold text-coffee mb-2">Finding your spot...</h2>
-        <p class="text-coffee-600 animate-pulse">Redirecting you to your last visited café.</p>
+        <h2 class="text-2xl font-bold text-coffee mb-2">{{ $t('pwa.finding') }}</h2>
+        <p class="text-coffee-600 animate-pulse">{{ $t('pwa.redirecting') }}</p>
     </div>
 </template>

--- a/app/pages/signup.vue
+++ b/app/pages/signup.vue
@@ -2,36 +2,39 @@
   <div class="bg-latte min-h-screen flex items-center justify-center p-4">
     <UCard class="w-full sm:max-w-sm bg-white dark:bg-latte-50 ring-1 ring-gray-200 dark:ring-gray-700">
       <template #header>
-        <h2 class="text-xl font-bold text-center text-coffee">Create Account</h2>
+        <div class="flex items-center justify-between gap-2">
+          <h2 class="text-xl font-bold text-coffee">{{ $t('auth.signup.title') }}</h2>
+          <LanguageSwitcher />
+        </div>
       </template>
 
       <UForm :state="state" :schema="schema" @submit="handleSignup" @error="handleError" class="flex flex-col space-y-4">
-        <UFormGroup label="Name" name="name" class="mb-4">
-          <UInput v-model="state.name" placeholder="Your Name" class="w-full">
+        <UFormGroup :label="$t('auth.fields.nameLabel')" name="name" class="mb-4">
+          <UInput v-model="state.name" :placeholder="$t('auth.fields.namePlaceholder')" class="w-full">
             <label class="pointer-events-none absolute left-0 -top-2.5 text-coffee text-xs font-medium px-1.5 transition-all peer-focus:-top-2.5 peer-focus:text-coffee peer-focus:text-xs peer-focus:font-medium peer-placeholder-shown:text-sm peer-placeholder-shown:text-gray-500 peer-placeholder-shown:top-1.5 peer-placeholder-shown:font-normal">
-              <span class="inline-flex bg-white dark:bg-latte-50 px-1">Your name</span>
+              <span class="inline-flex bg-white dark:bg-latte-50 px-1">{{ $t('auth.fields.nameFloating') }}</span>
             </label>
-          </UInput> 
+          </UInput>
         </UFormGroup>
 
-        <UFormGroup label="Email" name="email" class="mb-4">
-          <UInput v-model="state.email" type="email" placeholder="you@example.com" class="w-full">
+        <UFormGroup :label="$t('auth.fields.emailLabel')" name="email" class="mb-4">
+          <UInput v-model="state.email" type="email" :placeholder="$t('auth.fields.emailPlaceholder')" class="w-full">
             <label class="pointer-events-none absolute left-0 -top-2.5 text-coffee text-xs font-medium px-1.5 transition-all peer-focus:-top-2.5 peer-focus:text-coffee peer-focus:text-xs peer-focus:font-medium peer-placeholder-shown:text-sm peer-placeholder-shown:text-gray-500 peer-placeholder-shown:top-1.5 peer-placeholder-shown:font-normal">
-              <span class="inline-flex bg-white dark:bg-latte-50 px-1">Email</span>
+              <span class="inline-flex bg-white dark:bg-latte-50 px-1">{{ $t('auth.fields.emailFloating') }}</span>
             </label>
-          </UInput> 
+          </UInput>
         </UFormGroup>
 
 
-        <UFormGroup label="Café ID" name="cafeId" class="mb-4">
-          <UInput v-model="state.cafeID" placeholder="Café ID" class="w-full">
+        <UFormGroup :label="$t('auth.fields.cafeIdLabel')" name="cafeId" class="mb-4">
+          <UInput v-model="state.cafeID" :placeholder="$t('auth.fields.cafeIdPlaceholder')" class="w-full">
             <label class="pointer-events-none absolute left-0 -top-2.5 text-coffee text-xs font-medium px-1.5 transition-all peer-focus:-top-2.5 peer-focus:text-coffee peer-focus:text-xs peer-focus:font-medium peer-placeholder-shown:text-sm peer-placeholder-shown:text-gray-500 peer-placeholder-shown:top-1.5 peer-placeholder-shown:font-normal">
-              <span class="inline-flex bg-white dark:bg-latte-50 px-1">Your café ID</span>
+              <span class="inline-flex bg-white dark:bg-latte-50 px-1">{{ $t('auth.fields.cafeIdFloating') }}</span>
             </label>
-          </UInput> 
+          </UInput>
         </UFormGroup>
 
-        <UFormGroup label="Password" name="password" class="mb-6">
+        <UFormGroup :label="$t('auth.fields.passwordLabel')" name="password" class="mb-6">
           <UInput v-model="state.password" :type="showPassword ? 'text' : 'password'" placeholder="••••••••" :ui="{ trailing: 'pointer-events-auto' }" class="w-full">
             <template #trailing>
               <UButton
@@ -43,16 +46,16 @@
               />
             </template>
             <label class="pointer-events-none absolute left-0 -top-2.5 text-coffee text-xs font-medium px-1.5 transition-all peer-focus:-top-2.5 peer-focus:text-coffee peer-focus:text-xs peer-focus:font-medium peer-placeholder-shown:text-sm peer-placeholder-shown:text-gray-500 peer-placeholder-shown:top-1.5 peer-placeholder-shown:font-normal">
-              <span class="inline-flex bg-white dark:bg-latte-50 px-1">Password</span>
+              <span class="inline-flex bg-white dark:bg-latte-50 px-1">{{ $t('auth.fields.passwordFloating') }}</span>
             </label>
-          </UInput> 
+          </UInput>
         </UFormGroup>
         <div class="hidden" aria-hidden="true">
           <UCheckbox v-model="state.newsletter" label="Subscribe to newsletter" tabindex="-1" />
         </div>
 
         <UButton type="submit" block :loading="loading" class="bg-coffee-500 hover:bg-coffee-600 text-white">
-          Sign Up
+          {{ $t('auth.signup.submit') }}
         </UButton>
         <p v-if="hasErrors" class="text-red-500 text-sm text-center mt-2">
           {{ hasErrors.errors.map(err => err.message).join(', ') }}
@@ -62,10 +65,10 @@
       <template #footer>
         <div class="text-center">
           <span class="text-sm text-gray-500 dark:text-gray-400">
-            Already have an account?
+            {{ $t('auth.signup.haveAccount') }}
           </span>
           <NuxtLink to="/login" class="text-sm text-coffee-600 hover:underline ml-1 font-medium">
-            Log In
+            {{ $t('auth.signup.loginLink') }}
           </NuxtLink>
         </div>
       </template>
@@ -83,6 +86,7 @@ const account = $appwrite.account;
 const databases = $appwrite.databases;
 const toast = useToast();
 const router = useRouter();
+const { t } = useI18n();
 
 // Form state
 const state = reactive({
@@ -112,10 +116,10 @@ function sanitizeCafeID(input: string): string {
 
 // Validation schema using Zod
 const schema = z.object({
-  name: z.string().min(2, 'Name must be at least 2 characters'),
-  email: z.string().email('Invalid email address'),
-  password: z.string().min(8, 'Password must be at least 8 characters'),
-  cafeID: z.string().min(3, 'Cafe ID must be at least 3 characters'),
+  name: z.string().min(2, t('auth.validation.nameMin')),
+  email: z.string().email(t('auth.validation.invalidEmail')),
+  password: z.string().min(8, t('auth.validation.passwordMin')),
+  cafeID: z.string().min(3, t('auth.validation.cafeIdMin')),
   newsletter: z.boolean().optional()
 });
 
@@ -138,7 +142,7 @@ async function handleSignup(event: FormSubmitEvent<Schema>) {
   if (state.newsletter) {
     setTimeout(() => {
       loading.value = false;
-      toast.add({ title: 'Account Created!', description: 'Please login to continue.', color: 'primary' });
+      toast.add({ title: t('auth.signup.accountCreatedTitle'), description: t('auth.signup.accountCreatedDesc'), color: 'primary' });
       router.push('/login');
     }, 1000);
     return;
@@ -146,7 +150,7 @@ async function handleSignup(event: FormSubmitEvent<Schema>) {
 
   state.cafeID = sanitizeCafeID(state.cafeID);
   if (state.cafeID === 'undefined') {
-    toast.add({ title: 'Invalid Cafe ID', description: 'Cafe ID cannot be "undefined". Please choose a different cafe ID.', color: 'error' });
+    toast.add({ title: t('auth.signup.invalidCafeIdTitle'), description: t('auth.signup.invalidCafeIdDesc'), color: 'error' });
     loading.value = false;
     return;
   }
@@ -154,7 +158,7 @@ async function handleSignup(event: FormSubmitEvent<Schema>) {
   // Before creating a new account, verify that the cafeID does not already exsist in the database
   const alreadyExists = await databases.listDocuments('cafe', 'cafe', [Query.equal('$id', state.cafeID)]);
   if (alreadyExists.total > 0) {
-    toast.add({ title: 'Cafe ID already exists', description: 'Please choose a different cafe ID.', color: 'error' });
+    toast.add({ title: t('auth.signup.cafeIdExistsTitle'), description: t('auth.signup.cafeIdExistsDesc'), color: 'error' });
     loading.value = false;
     return;
   }
@@ -171,7 +175,7 @@ async function handleSignup(event: FormSubmitEvent<Schema>) {
       name
     );
 
-    toast.add({ title: 'Account Created!', description: 'Please login to continue.', color: 'primary' });
+    toast.add({ title: t('auth.signup.accountCreatedTitle'), description: t('auth.signup.accountCreatedDesc'), color: 'primary' });
 
     // Create a new email session
     await account.createEmailPasswordSession(email, password);
@@ -204,7 +208,7 @@ async function handleSignup(event: FormSubmitEvent<Schema>) {
 
   } catch (error: any) {
     console.error('Signup failed:', error);
-    toast.add({ title: 'Signup Failed', description: error.message || 'An unexpected error occurred.', color: 'error' });
+    toast.add({ title: t('auth.signup.failTitle'), description: error.message || t('auth.signup.failDesc'), color: 'error' });
   } finally {
     loading.value = false;
   }

--- a/app/pages/undefined/[any].vue
+++ b/app/pages/undefined/[any].vue
@@ -2,32 +2,35 @@
   <div class="bg-latte min-h-screen flex items-center justify-center p-4">
     <UCard class="w-full sm:max-w-sm bg-white dark:bg-latte-50 ring-1 ring-gray-200 dark:ring-gray-700">
       <template #header>
-        <h2 class="text-xl font-bold text-center text-coffee">Complete Cafe Setup</h2>
+        <div class="flex items-center justify-between gap-2">
+          <h2 class="text-xl font-bold text-coffee">{{ $t('setup.title') }}</h2>
+          <LanguageSwitcher />
+        </div>
       </template>
 
       <div class="mb-6 text-sm text-gray-600 dark:text-gray-400 text-center">
-        It seems something went wrong during the setup of your cafe. Please provide your cafe details to continue.
+        {{ $t('setup.intro') }}
       </div>
 
       <UForm :state="state" :schema="schema" @submit="handleSetup" @error="handleError" class="flex flex-col space-y-4">
-        <UFormGroup label="Cafe Name" name="name" class="mb-4">
-          <UInput v-model="state.name" placeholder="My Awesome Cafe" class="w-full">
+        <UFormGroup :label="$t('setup.cafeNameLabel')" name="name" class="mb-4">
+          <UInput v-model="state.name" :placeholder="$t('setup.cafeNamePlaceholder')" class="w-full">
             <label class="pointer-events-none absolute left-0 -top-2.5 text-coffee text-xs font-medium px-1.5 transition-all peer-focus:-top-2.5 peer-focus:text-coffee peer-focus:text-xs peer-focus:font-medium peer-placeholder-shown:text-sm peer-placeholder-shown:text-gray-500 peer-placeholder-shown:top-1.5 peer-placeholder-shown:font-normal">
-              <span class="inline-flex bg-white dark:bg-latte-50 px-1">Cafe Name</span>
+              <span class="inline-flex bg-white dark:bg-latte-50 px-1">{{ $t('setup.cafeNameFloating') }}</span>
             </label>
           </UInput>
         </UFormGroup>
-        <p>Your café name cannot contain special characters or spaces.</p>
-        <UFormGroup label="Café ID" name="cafeId" class="mb-4">
-          <UInput v-model="state.cafeID" placeholder="cafe-id" class="w-full">
+        <p>{{ $t('setup.noSpecialChars') }}</p>
+        <UFormGroup :label="$t('setup.cafeIdLabel')" name="cafeId" class="mb-4">
+          <UInput v-model="state.cafeID" :placeholder="$t('setup.cafeIdPlaceholder')" class="w-full">
             <label class="pointer-events-none absolute left-0 -top-2.5 text-coffee text-xs font-medium px-1.5 transition-all peer-focus:-top-2.5 peer-focus:text-coffee peer-focus:text-xs peer-focus:font-medium peer-placeholder-shown:text-sm peer-placeholder-shown:text-gray-500 peer-placeholder-shown:top-1.5 peer-placeholder-shown:font-normal">
-              <span class="inline-flex bg-white dark:bg-latte-50 px-1">Your café ID</span>
+              <span class="inline-flex bg-white dark:bg-latte-50 px-1">{{ $t('setup.cafeIdFloating') }}</span>
             </label>
           </UInput>
         </UFormGroup>
 
         <UButton type="submit" block :loading="loading" class="bg-coffee-500 hover:bg-coffee-600 text-white">
-          Complete Setup
+          {{ $t('setup.submit') }}
         </UButton>
         <p v-if="hasErrors" class="text-red-500 text-sm text-center mt-2">
           {{ hasErrors.errors.map(err => err.message).join(', ') }}
@@ -47,6 +50,7 @@ const account = $appwrite.account;
 const databases = $appwrite.databases;
 const toast = useToast();
 const router = useRouter();
+const { t } = useI18n();
 
 onMounted(async () => {
   try {
@@ -54,7 +58,7 @@ onMounted(async () => {
     if (user.prefs && user.prefs.cafeID) {
       try {
         await databases.getDocument('cafe', 'cafe', user.prefs.cafeID);
-        toast.add({ title: 'Cafe Found', description: 'Redirecting to your cafe...', color: 'primary' });
+        toast.add({ title: t('setup.cafeFoundTitle'), description: t('setup.cafeFoundDesc'), color: 'primary' });
         router.push(`/${user.prefs.cafeID}/barista/menu`);
       } catch (e) {
         // Cafe not found, stay on page to create it
@@ -89,8 +93,8 @@ function sanitizeCafeID(input: string): string {
 
 // Validation schema using Zod
 const schema = z.object({
-  name: z.string().min(2, 'Name must be at least 2 characters'),
-  cafeID: z.string().min(3, 'Cafe ID must be at least 3 characters')
+  name: z.string().min(2, t('setup.validation.nameMin')),
+  cafeID: z.string().min(3, t('setup.validation.cafeIdMin'))
 });
 
 type Schema = z.output<typeof schema>;
@@ -111,7 +115,7 @@ async function handleSetup(event: FormSubmitEvent<Schema>) {
     try {
         await account.get();
     } catch (e) {
-        toast.add({ title: 'Authentication Error', description: 'You need to be logged in to complete setup.', color: 'error' });
+        toast.add({ title: t('setup.authErrorTitle'), description: t('setup.authErrorDesc'), color: 'error' });
         router.push('/login');
         return;
     }
@@ -119,14 +123,14 @@ async function handleSetup(event: FormSubmitEvent<Schema>) {
     // Check if cafeID already exists
     const alreadyExists = await databases.listDocuments('cafe', 'cafe', [Query.equal('$id', state.cafeID)]);
     if (alreadyExists.total > 0) {
-      toast.add({ title: 'Cafe ID already exists', description: 'Please choose a different cafe ID.', color: 'error' });
+      toast.add({ title: t('setup.cafeIdExistsTitle'), description: t('setup.cafeIdExistsDesc'), color: 'error' });
       loading.value = false;
       return;
     }
 
 
   if (state.cafeID === 'undefined') {
-    toast.add({ title: 'Invalid Cafe ID', description: 'Cafe ID cannot be "undefined". Please choose a different cafe ID.', color: 'error' });
+    toast.add({ title: t('setup.invalidCafeIdTitle'), description: t('setup.invalidCafeIdDesc'), color: 'error' });
     loading.value = false;
     return;
   }
@@ -155,14 +159,14 @@ async function handleSetup(event: FormSubmitEvent<Schema>) {
         cafeID: state.cafeID,
     });
 
-    toast.add({ title: 'Setup Complete!', description: 'Your cafe is ready.', color: 'primary' });
+    toast.add({ title: t('setup.completeTitle'), description: t('setup.completeDesc'), color: 'primary' });
 
     // Redirect to barista menu
     router.push(`/${state.cafeID}/barista/menu`);
 
   } catch (error: any) {
     console.error('Setup failed:', error);
-    toast.add({ title: 'Setup Failed', description: error.message || 'An unexpected error occurred.', color: 'error' });
+    toast.add({ title: t('setup.failTitle'), description: error.message || t('setup.failDesc'), color: 'error' });
   } finally {
     loading.value = false;
   }

--- a/i18n/i18n.config.ts
+++ b/i18n/i18n.config.ts
@@ -1,0 +1,6 @@
+// https://i18n.nuxtjs.org/docs/guide/vue-i18n-configuration
+// Runtime vue-i18n options (Composition API, English fallback for missing keys).
+export default defineI18nConfig(() => ({
+  legacy: false,
+  fallbackLocale: 'en',
+}))

--- a/i18n/locales/de.json
+++ b/i18n/locales/de.json
@@ -1,0 +1,475 @@
+{
+  "common": {
+    "cancel": "Abbrechen",
+    "save": "Speichern",
+    "delete": "Löschen",
+    "edit": "Bearbeiten",
+    "close": "Schließen",
+    "copy": "Kopieren",
+    "copied": "Kopiert!",
+    "loading": "Wird geladen ..."
+  },
+  "nav": {
+    "orders": "Bestellungen",
+    "menu": "Karte",
+    "cafe": "Café"
+  },
+  "languageSwitcher": {
+    "label": "Sprache"
+  },
+  "app": {
+    "name": "My Tiny Café",
+    "description": "Bestelle in deinem Lieblingscafé"
+  },
+  "landing": {
+    "nav": {
+      "login": "Anmelden",
+      "openCafe": "My Tiny Café eröffnen"
+    },
+    "hero": {
+      "title": "Mach dein Zuhause zum {highlight} der Stadt.",
+      "titleHighlight": "besten Café",
+      "subtitle": "Die digitale Karte für Heim-Baristas. Erstelle deine Getränkeliste, teile deinen QR-Code mit Freunden und Familie und empfange Bestellungen direkt auf deinem Handy.",
+      "subtitleEmphasis": "100 % kostenlos. 100 % gemütlich.",
+      "ctaPrimary": "My Tiny Café eröffnen",
+      "ctaDemo": "Demo-Café ansehen ↗",
+      "noCreditCard": "Keine Kreditkarte nötig. Keine Werbung. Einfach nur Liebe."
+    },
+    "mockup": {
+      "notifTitle": "Neue Bestellung von Magali",
+      "notifOrder": "Latte (Hafermilch, ohne Zucker)",
+      "now": "jetzt",
+      "menu": "Karte",
+      "latte": "Latte",
+      "lattePrice": "1 Umarmung 🤗",
+      "matcha": "Matcha",
+      "tea": "Tee",
+      "teaPrice": "Eine Geschichte 📖",
+      "cookie": "Cookie",
+      "cookiePrice": "Gratis!"
+    },
+    "valueProp": {
+      "eyebrow": "Gastfreundschaft, neu gedacht",
+      "heading": "Warum aus der Küche rufen?",
+      "problemTitle": "Das Problem",
+      "problemText": "Aus der Küche rufen: „Wer will Tee?“ – und bis das Wasser kocht, hast du längst vergessen, wer Zucker und wer Mandelmilch wollte.",
+      "solutionTitle": "Die Lösung",
+      "solutionText": "My Tiny Café bringt das Flair eines Boutique-Cafés in dein Wohnzimmer. Mach den Moment zu etwas Besonderem."
+    },
+    "howItWorks": {
+      "title": "So funktioniert's (in 3 einfachen Schritten)",
+      "step1Title": "1. Erstelle deine Karte",
+      "step1Text": "Gib deinem Café einen Namen. Füge deine Spezialitäten hinzu – Latte, Tee oder Tartine. Passe Optionen für Milch und Zucker an.",
+      "step2Title": "2. Teile den Link",
+      "step2Text": "Druck deinen QR-Code für den Kühlschrank aus oder verschick den Link. Deine Gäste stöbern und stellen sich ihr Getränk genau nach Geschmack zusammen.",
+      "step3Title": "3. Bestellung erhalten & servieren",
+      "step3Text": "Ding! Du bekommst sofort eine Benachrichtigung. Kein Geld wechselt den Besitzer – nur die perfekte Tasse, serviert mit einem Lächeln."
+    },
+    "features": {
+      "title": "Funktionen",
+      "feature1Title": "Voll anpassbare Karte",
+      "feature1Text": "Von „Stilltee“ bis „Iced Matcha“ – du bestimmst, was du servierst.",
+      "feature2Title": "Sofortige Push-Benachrichtigungen",
+      "feature2Text": "Verpasse keine Bestellung mehr. Du weißt in der Sekunde Bescheid, in der dein „Gast“ seine Bestellung abschickt.",
+      "feature3Title": "Kein App-Download",
+      "feature3Text": "Deine Gäste scannen (oder klicken) einfach und bestellen. Keine Installation nötig.",
+      "feature4Title": "Komplett kostenlos",
+      "feature4Text": "Keine Zahlungsdienste. Die einzige Währung hier ist Dankbarkeit."
+    },
+    "stories": {
+      "title": "Echte Geschichten",
+      "quote1": "Papa, darf ich mit deiner App einen Tee bestellen?",
+      "quote1Name": "Zola, 5 Jahre",
+      "quote1Role": "Chef-Geschmackstesterin",
+      "quote2": "Es ist so viel einfacher, mir einen Kaffee für die Heimkehr zu bestellen. Und der Barista ist auch noch superniedlich!",
+      "quote2Name": "Magali",
+      "quote2Role": "Ehefrau & treue Kundin"
+    },
+    "audience": {
+      "title": "Für wen ist My Tiny Café?",
+      "card1Title": "Das Homeoffice-Power-Paar",
+      "card1Text": "Schick eine stille Bestellung für den Koffeinschub, ohne das Zoom-Meeting zu unterbrechen.",
+      "card2Title": "Der Gastgeber mit dem gewissen Etwas",
+      "card2Text": "Beeindrucke deine Gäste, indem sie ihren Digestif nach dem Essen über eine digitale Karte bestellen.",
+      "card3Title": "Die verspielten Eltern",
+      "card3Text": "Kinder lieben es, „Restaurant“ zu spielen. Richte die Karte für sie ein und lass sie deine Bestellung aufnehmen."
+    },
+    "faq": {
+      "title": "Häufige Fragen",
+      "q1": "Ist es wirklich kostenlos?",
+      "a1": "Ja! My Tiny Café ist derzeit völlig kostenlos nutzbar.",
+      "q2": "Kann ich Geld für die Getränke verlangen?",
+      "a2": "Nein. Diese App ist für Freunde und Familie gedacht. Es gibt keine Zahlungsabwicklung – nur die Freude, jemandem, der dir am Herzen liegt, ein Getränk zu servieren.",
+      "q3": "Was kann ich auf die Karte setzen?",
+      "a3": "Alles! Kaffee, Tee, Snacks, Tartines, Wasser ... Wenn du es in deiner Küche zubereiten kannst, kannst du es auf deine Karte setzen."
+    },
+    "openSource": {
+      "title": "Mit Stolz Open Source",
+      "text": "Ich glaube an Transparenz und Gemeinschaft. My Tiny Café ist Open Source – du kannst also genau sehen, wie es gebaut ist, Funktionen beisteuern oder es selbst hosten.",
+      "button": "Auf GitHub ansehen"
+    },
+    "footer": {
+      "title": "Bereit, dein Café zu eröffnen?",
+      "subtitle": "Werde noch heute Teil der Community aus Heim-Baristas.",
+      "cta": "Jetzt dein Café erstellen",
+      "madeWith": "Mit ❤️ in Frankreich gemacht, für Zola und Magali.",
+      "copyright": "© 2024 My Tiny Café",
+      "aboutMakerTitle": "Über den Macher",
+      "aboutMakerText": "Ich bin Alix und habe das hier gebaut, um meine Frau und meine Tochter glücklich zu machen. Ich hoffe, es bringt auch ein bisschen Freude in dein Zuhause. Ich bin freiberuflicher Frontend-Entwickler (am liebsten mit Vue.js / Nuxt.js) mit einem Hintergrund in der Forschung zur Mensch-Computer-Interaktion. {link}.",
+      "aboutMakerLink": "Schau dir meine Arbeit an",
+      "guest": "Gast?",
+      "findCafe": "Café finden"
+    }
+  },
+  "auth": {
+    "fields": {
+      "emailLabel": "E-Mail",
+      "emailPlaceholder": "du{'@'}beispiel.de",
+      "emailFloating": "E-Mail",
+      "passwordLabel": "Passwort",
+      "passwordFloating": "Passwort",
+      "nameLabel": "Name",
+      "namePlaceholder": "Dein Name",
+      "nameFloating": "Dein Name",
+      "cafeIdLabel": "Café-ID",
+      "cafeIdPlaceholder": "Café-ID",
+      "cafeIdFloating": "Deine Café-ID"
+    },
+    "validation": {
+      "invalidEmail": "Ungültige E-Mail-Adresse",
+      "passwordMin": "Das Passwort muss mindestens 8 Zeichen lang sein",
+      "nameMin": "Der Name muss mindestens 2 Zeichen lang sein",
+      "cafeIdMin": "Die Café-ID muss mindestens 3 Zeichen lang sein"
+    },
+    "login": {
+      "title": "Anmelden",
+      "submit": "Anmelden",
+      "noAccount": "Noch kein Konto?",
+      "signupLink": "Registrieren",
+      "successTitle": "Anmeldung erfolgreich!",
+      "successDesc": "Du wirst weitergeleitet ...",
+      "failTitle": "Anmeldung fehlgeschlagen",
+      "errorUnexpected": "Ein unerwarteter Fehler ist aufgetreten. Bitte versuche es erneut."
+    },
+    "signup": {
+      "title": "Konto erstellen",
+      "submit": "Registrieren",
+      "haveAccount": "Hast du bereits ein Konto?",
+      "loginLink": "Anmelden",
+      "accountCreatedTitle": "Konto erstellt!",
+      "accountCreatedDesc": "Bitte melde dich an, um fortzufahren.",
+      "invalidCafeIdTitle": "Ungültige Café-ID",
+      "invalidCafeIdDesc": "Die Café-ID darf nicht „undefined“ sein. Bitte wähle eine andere Café-ID.",
+      "cafeIdExistsTitle": "Café-ID existiert bereits",
+      "cafeIdExistsDesc": "Bitte wähle eine andere Café-ID.",
+      "failTitle": "Registrierung fehlgeschlagen",
+      "failDesc": "Ein unerwarteter Fehler ist aufgetreten."
+    }
+  },
+  "setup": {
+    "title": "Café-Einrichtung abschließen",
+    "intro": "Bei der Einrichtung deines Cafés scheint etwas schiefgelaufen zu sein. Bitte gib deine Café-Daten an, um fortzufahren.",
+    "cafeNameLabel": "Café-Name",
+    "cafeNamePlaceholder": "Mein tolles Café",
+    "cafeNameFloating": "Café-Name",
+    "noSpecialChars": "Dein Café-Name darf keine Sonderzeichen oder Leerzeichen enthalten.",
+    "cafeIdLabel": "Café-ID",
+    "cafeIdPlaceholder": "cafe-id",
+    "cafeIdFloating": "Deine Café-ID",
+    "submit": "Einrichtung abschließen",
+    "cafeFoundTitle": "Café gefunden",
+    "cafeFoundDesc": "Du wirst zu deinem Café weitergeleitet ...",
+    "authErrorTitle": "Authentifizierungsfehler",
+    "authErrorDesc": "Du musst angemeldet sein, um die Einrichtung abzuschließen.",
+    "cafeIdExistsTitle": "Café-ID existiert bereits",
+    "cafeIdExistsDesc": "Bitte wähle eine andere Café-ID.",
+    "invalidCafeIdTitle": "Ungültige Café-ID",
+    "invalidCafeIdDesc": "Die Café-ID darf nicht „undefined“ sein. Bitte wähle eine andere Café-ID.",
+    "completeTitle": "Einrichtung abgeschlossen!",
+    "completeDesc": "Dein Café ist bereit.",
+    "failTitle": "Einrichtung fehlgeschlagen",
+    "failDesc": "Ein unerwarteter Fehler ist aufgetreten.",
+    "validation": {
+      "nameMin": "Der Name muss mindestens 2 Zeichen lang sein",
+      "cafeIdMin": "Die Café-ID muss mindestens 3 Zeichen lang sein"
+    }
+  },
+  "menu": {
+    "beBarista": "Sei der Barista",
+    "heading": "Karte",
+    "pastOrders": "Frühere Bestellungen",
+    "unknownItem": "Unbekannter Artikel",
+    "yourName": "Dein Name",
+    "order": "Bestellen",
+    "anonymous": "Anonym",
+    "status": {
+      "ordered": "Deine Bestellung wird zubereitet",
+      "completed": "Deine Bestellung ist fertig!",
+      "canceled": "Deine Bestellung wurde storniert",
+      "unknown": "Unbekannter Status"
+    },
+    "toast": {
+      "orderSentTitle": "Bestellung gesendet",
+      "orderSentDesc": "Deine Bestellung wurde erfolgreich gesendet.",
+      "errorTitle": "Fehler",
+      "orderFailDesc": "Deine Bestellung konnte nicht gesendet werden. Bitte versuche es erneut.",
+      "orderCanceledTitle": "Bestellung storniert",
+      "orderCanceledDesc": "Deine Bestellung wurde erfolgreich storniert.",
+      "cancelFailDesc": "Deine Bestellung konnte nicht storniert werden. Bitte versuche es erneut."
+    },
+    "headDescription": "Bestelle deine Lieblingsartikel bei {cafeName}"
+  },
+  "baristaOrders": {
+    "title": "Bestellung",
+    "enableNotifications": "Erhalte eine Benachrichtigung, wenn eine neue Bestellung eingeht",
+    "emptyTitle": "Noch keine Bestellungen",
+    "emptyText": "Teile deine Café-Seite, um Bestellungen zu erhalten!",
+    "shareCafe": "Mein Café teilen",
+    "pastOrders": "Frühere Bestellungen",
+    "cancel": "Stornieren",
+    "complete": "Fertigstellen",
+    "unknownItem": "Unbekannter Artikel",
+    "statusLabel": {
+      "ordered": "Bestellt",
+      "completed": "Fertig",
+      "canceled": "Storniert"
+    }
+  },
+  "baristaMenu": {
+    "manageMenuFor": "Karte verwalten für {cafeName}",
+    "cafeId": "Café-ID: {id}",
+    "addNewItem": "Neuen Artikel hinzufügen",
+    "noItemsTitle": "Noch keine Artikel",
+    "noItemsText": "Leg los, indem du einen neuen Artikel hinzufügst.",
+    "options": "Optionen:",
+    "yesNo": "Ja / Nein",
+    "noOptions": "Keine spezifischen Optionen festgelegt.",
+    "edit": "Bearbeiten",
+    "delete": "Löschen",
+    "editItemTitle": "{name} bearbeiten",
+    "addItemTitle": "Neuen Artikel hinzufügen",
+    "itemNamePlaceholder": "z. B. Espresso, Croissant",
+    "itemNameFloating": "Artikelname",
+    "pricePlaceholder": "z. B. 3,50",
+    "priceFloating": "Preis",
+    "imageLabel": "Bild",
+    "noImage": "Kein Bild",
+    "descriptionPlaceholder": "Artikelbeschreibung ...",
+    "descriptionFloating": "Beschreibung",
+    "optionNamePlaceholder": "z. B. Größe, Milch, Entkoffeiniert",
+    "optionNameFloating": "Optionsname",
+    "multipleValues": "Mehrere Werte / Einfache Option",
+    "valuesFor": "Werte für {name}:",
+    "thisOption": "diese Option",
+    "valuePlaceholder": "z. B. Klein, Groß, Hafermilch",
+    "valueFloating": "Wert",
+    "addValue": "Wert hinzufügen",
+    "addNewOptionType": "Neuen Optionstyp hinzufügen",
+    "removeOption": "Option entfernen",
+    "removeValue": "Wert entfernen",
+    "cancel": "Abbrechen",
+    "saveChanges": "Änderungen speichern",
+    "addItem": "Artikel hinzufügen",
+    "confirmDelete": "Möchtest du diesen Artikel wirklich löschen? Diese Aktion kann nicht rückgängig gemacht werden.",
+    "images": {
+      "bobba": "Bubble Tea",
+      "cafe": "Kaffee",
+      "cookie": "Cookie",
+      "emporter": "Zum Mitnehmen",
+      "gaiwan": "Gaiwan",
+      "jus": "Saft",
+      "latte": "Latte",
+      "muffin": "Muffin",
+      "mug": "Becher",
+      "tartine": "Tartine",
+      "the": "Tee",
+      "yaourt": "Joghurt"
+    },
+    "toast": {
+      "errorLoadingCafeTitle": "Fehler beim Laden des Cafés",
+      "errorLoadingCafeDesc": "Das angeforderte Café konnte nicht gefunden oder geladen werden.",
+      "errorLoadingMenuTitle": "Fehler beim Laden der Karte",
+      "errorLoadingMenuDesc": "Die Artikel der Karte konnten nicht geladen werden.",
+      "errorTitle": "Fehler",
+      "cafeIdMissing": "Café-ID fehlt.",
+      "itemDeletedTitle": "Artikel gelöscht",
+      "itemDeletedDesc": "Der Artikel wurde erfolgreich gelöscht.",
+      "deletionFailedTitle": "Löschen fehlgeschlagen",
+      "deletionFailedDesc": "Der Artikel konnte nicht gelöscht werden.",
+      "validationErrorTitle": "Validierungsfehler",
+      "itemNameRequired": "Artikelname ist erforderlich.",
+      "itemUpdatedTitle": "Artikel aktualisiert",
+      "itemUpdatedDesc": "Änderungen erfolgreich gespeichert.",
+      "itemAddedTitle": "Artikel hinzugefügt",
+      "itemAddedDesc": "Neuer Artikel zur Karte hinzugefügt.",
+      "saveFailedTitle": "Speichern fehlgeschlagen",
+      "saveFailedDesc": "Der Artikel konnte nicht gespeichert werden."
+    }
+  },
+  "cafeSettings": {
+    "share": {
+      "title": "Teile deine Seite",
+      "subtitle": "Teile diese Seite über die URL oder den QR-Code unten.",
+      "pageUrlLabel": "Seiten-URL",
+      "pageUrlHelp": "Das ist der direkte Link zu deiner Seite.",
+      "generatingUrl": "URL wird erstellt ..."
+    },
+    "qr": {
+      "title": "QR-Code",
+      "subtitle": "Scanne diesen QR-Code mit einem mobilen Gerät, um die Seite zu öffnen.",
+      "downloadPng": "PNG herunterladen",
+      "unavailable": "Seiten-URL nicht verfügbar, der QR-Code kann nicht generiert werden."
+    },
+    "updateName": {
+      "title": "Café-Namen ändern",
+      "subtitle": "Ändere den Namen deines Cafés.",
+      "label": "Café-Name",
+      "help": "Gib den neuen Namen für dein Café ein.",
+      "placeholder": "Neuen Café-Namen eingeben",
+      "update": "Aktualisieren",
+      "updating": "Wird aktualisiert ..."
+    },
+    "customImages": {
+      "title": "Eigene Bilder",
+      "subtitle": "Lade deine eigenen Bilder hoch, um sie in deinen Artikeln zu verwenden.",
+      "upload": "Bild hochladen",
+      "empty": "Noch keine eigenen Bilder. Lade eins hoch, um loszulegen."
+    },
+    "about": {
+      "title": "Über & Unterstützung",
+      "openSourceTitle": "Open Source",
+      "openSourceText": "Dieses Projekt ist teilweise Open Source. Die auf GitHub verfügbare Appwrite-Serverkonfiguration ist wahrscheinlich veraltet – melde dich, falls du etwas brauchst.",
+      "viewOnGithub": "Auf GitHub ansehen",
+      "contactTitle": "Den Macher kontaktieren",
+      "contactText": "Gebaut von Alix. Melde dich, falls du etwas brauchst.",
+      "hireText": "Wie wäre es, mich für dein nächstes Projekt zu engagieren?",
+      "supportTitle": "Unterstütze My Tiny Café",
+      "supportText": "My Tiny Café ist kostenlos verfügbar, aber wenn du es gerne nutzt, kannst du gerne zu den Hosting-Kosten beitragen.",
+      "supportButton": "Auf Buy Me a Coffee unterstützen"
+    },
+    "delete": {
+      "title": "Konto löschen",
+      "subtitle": "Lösche dein Café, seine Karte, alle Bestellungen, alle eigenen Bilder und dein Konto endgültig. Diese Aktion kann nicht rückgängig gemacht werden.",
+      "button": "Mein Konto löschen",
+      "modalTitle": "Dein Konto endgültig löschen?",
+      "modalIntro": "Dadurch wird Folgendes endgültig gelöscht:",
+      "modalListCafe": "dein Café {id}",
+      "modalListMenu": "seine Artikel und alle früheren Bestellungen",
+      "modalListImages": "deine eigenen Bilder",
+      "modalListAccount": "dein Konto (du kannst dich nicht mehr anmelden)",
+      "confirmLabel": "Gib „{cafeId}“ ein, um zu bestätigen",
+      "deletePermanently": "Endgültig löschen"
+    },
+    "session": {
+      "title": "Sitzung",
+      "subtitle": "Melde dich auf diesem Gerät ab. Du kannst dich jederzeit wieder anmelden.",
+      "logout": "Abmelden"
+    },
+    "toast": {
+      "imageUploadedTitle": "Bild hochgeladen",
+      "imageUploadedDesc": "„{name}“ wurde hochgeladen.",
+      "uploadFailedTitle": "Hochladen fehlgeschlagen",
+      "uploadFailedDesc": "Das Bild konnte nicht hochgeladen werden.",
+      "confirmDeleteImage": "Dieses Bild löschen? Artikel, die es verwenden, zeigen ein defektes Bild an.",
+      "imageDeletedTitle": "Bild gelöscht",
+      "imageDeletedDesc": "Das Bild wurde gelöscht.",
+      "deleteFailedTitle": "Löschen fehlgeschlagen",
+      "deleteFailedDesc": "Das Bild konnte nicht gelöscht werden.",
+      "errorTitle": "Fehler",
+      "cafeIdUnavailable": "Café-ID ist nicht verfügbar. Name kann nicht aktualisiert werden.",
+      "validationErrorTitle": "Validierungsfehler",
+      "cafeNameEmpty": "Der Café-Name darf nicht leer sein.",
+      "successTitle": "Erfolg!",
+      "cafeNameUpdated": "Café-Name geändert zu „{name}“.",
+      "updateFailedTitle": "Aktualisierung fehlgeschlagen",
+      "updateNameFailedDesc": "Der Café-Name konnte nicht aktualisiert werden. Bitte versuche es erneut.",
+      "missingCafeIdTitle": "Café-ID fehlt",
+      "missingCafeIdDesc": "Der eindeutige Bezeichner für das Café fehlt in der URL.",
+      "urlNotAvailableTitle": "URL nicht verfügbar",
+      "urlNotAvailableDesc": "Die Seiten-URL ist noch nicht bereit zum Kopieren.",
+      "clipboardDeniedTitle": "Zugriff auf die Zwischenablage verweigert",
+      "clipboardDeniedDesc": "Deine Browsereinstellungen verhindern den Zugriff auf die Zwischenablage, oder er wird nicht unterstützt.",
+      "urlCopiedTitle": "URL kopiert!",
+      "urlCopiedDesc": "Die Seiten-URL wurde in deine Zwischenablage kopiert.",
+      "copyUnconfirmedTitle": "Kopieren nicht bestätigt",
+      "copyUnconfirmedDesc": "Kopieren wurde versucht. Bitte überprüfe deine Zwischenablage.",
+      "copyFailedTitle": "Kopieren fehlgeschlagen",
+      "copyFailedDesc": "Beim Kopieren der URL ist ein Fehler aufgetreten. Bitte kopiere sie manuell.",
+      "downloadFailedTitle": "Download fehlgeschlagen",
+      "qrNotReady": "Der QR-Code ist noch nicht bereit. Bitte versuche es erneut.",
+      "qrDownloadedTitle": "QR-Code heruntergeladen",
+      "qrDownloadedDesc": "Das QR-Code-PNG wurde gespeichert.",
+      "qrGenerateFailed": "Die PNG-Datei konnte nicht generiert werden. Bitte versuche es erneut.",
+      "loggedOutTitle": "Abgemeldet",
+      "loggedOutDesc": "Du wurdest abgemeldet",
+      "accountDeletedTitle": "Konto gelöscht",
+      "accountDeletedDesc": "Dein Konto und dein Café wurden endgültig gelöscht.",
+      "deletionFailedTitle": "Löschen fehlgeschlagen",
+      "deletionFailedDesc": "Dein Konto konnte nicht gelöscht werden. Bitte versuche es erneut."
+    }
+  },
+  "invalidCafe": {
+    "title": "Dieses Café ist geschlossen.",
+    "text": "Wir konnten unter dieser Adresse kein Café finden. Vielleicht stimmt der Link nicht – oder vielleicht ist es Zeit für {you}, ein eigenes zu eröffnen?",
+    "textHighlight": "dich",
+    "openOwn": "Mein eigenes Café eröffnen",
+    "backHome": "Zurück zur Startseite",
+    "noCreditCard": "Keine Kreditkarte. Keine Werbung. Einfach nur Liebe.",
+    "headTitle": "Café nicht gefunden – My Tiny Café"
+  },
+  "pwa": {
+    "finding": "Dein Plätzchen wird gesucht ...",
+    "redirecting": "Du wirst zu deinem zuletzt besuchten Café weitergeleitet."
+  },
+  "demo": {
+    "cafeName": "Chez Zola",
+    "promptTitle": "Möchtest du dein eigenes Heim-Café?",
+    "promptText": "Wenn du dein eigenes kleines Café für Freunde und Familie eröffnen möchtest, registriere dich – es ist völlig kostenlos, werbefrei und dauert nur etwa eine Minute.",
+    "openCafe": "Mein kleines Café eröffnen",
+    "keepBrowsing": "Weiterstöbern",
+    "items": {
+      "latte": {
+        "name": "Latte",
+        "description": "Seidiger Espresso, gekrönt von aufgeschäumter Milch.",
+        "price": "1 Umarmung 🤗"
+      },
+      "espresso": {
+        "name": "Espresso",
+        "description": "Kurz, dunkel, intensiv. Der Klassiker."
+      },
+      "matcha": {
+        "name": "Matcha",
+        "description": "Aufgeschlagener grüner Tee in Zeremonie-Qualität."
+      },
+      "tea": {
+        "name": "Tee",
+        "description": "Loser Blatttee, frisch aufgegossen."
+      },
+      "juice": {
+        "name": "Frischer Saft",
+        "description": "Heute Morgen frisch gepresst."
+      },
+      "bubble": {
+        "name": "Bubble Tea",
+        "description": "Zähe Tapioka-Perlen, in deiner Lieblingssorte."
+      },
+      "muffin": {
+        "name": "Muffin",
+        "description": "Heute Morgen frisch gebacken."
+      },
+      "cookie": {
+        "name": "Cookie",
+        "description": "Warm und zäh."
+      },
+      "tartine": {
+        "name": "Tartine",
+        "description": "Sauerteigbrot, getoastet, mit Belag."
+      },
+      "yogurt": {
+        "name": "Joghurt",
+        "description": "Griechischer Joghurt, frische Früchte, Granola.",
+        "price": "Gratis!"
+      }
+    }
+  }
+}

--- a/i18n/locales/en.json
+++ b/i18n/locales/en.json
@@ -1,0 +1,475 @@
+{
+  "common": {
+    "cancel": "Cancel",
+    "save": "Save",
+    "delete": "Delete",
+    "edit": "Edit",
+    "close": "Close",
+    "copy": "Copy",
+    "copied": "Copied!",
+    "loading": "Loading..."
+  },
+  "nav": {
+    "orders": "Orders",
+    "menu": "Menu",
+    "cafe": "Cafe"
+  },
+  "languageSwitcher": {
+    "label": "Language"
+  },
+  "app": {
+    "name": "My Tiny Café",
+    "description": "Order your favorite café"
+  },
+  "landing": {
+    "nav": {
+      "login": "Login",
+      "openCafe": "Open My Tiny Café"
+    },
+    "hero": {
+      "title": "Turn Your Home into the {highlight} in Town.",
+      "titleHighlight": "Best Coffee Shop",
+      "subtitle": "The digital menu for home baristas. Create your drink list, share your QR code with friends and family, and receive orders straight to your phone.",
+      "subtitleEmphasis": "100% Free. 100% Cozy.",
+      "ctaPrimary": "Open My Tiny Café",
+      "ctaDemo": "See a demo café ↗",
+      "noCreditCard": "No credit card required. No ads. Just love."
+    },
+    "mockup": {
+      "notifTitle": "New Order from Magali",
+      "notifOrder": "Latte (Oat Milk, No Sugar)",
+      "now": "now",
+      "menu": "Menu",
+      "latte": "Latte",
+      "lattePrice": "1 hug 🤗",
+      "matcha": "Matcha",
+      "tea": "Tea",
+      "teaPrice": "A story 📖",
+      "cookie": "Cookie",
+      "cookiePrice": "Free!"
+    },
+    "valueProp": {
+      "eyebrow": "Hospitality, Upgraded",
+      "heading": "Why shout from the kitchen?",
+      "problemTitle": "The Problem",
+      "problemText": "Shouting from the kitchen, \"Who wants tea?\" and forgetting who wanted sugar and who wanted almond milk by the time the kettle boils.",
+      "solutionTitle": "The Solution",
+      "solutionText": "My Tiny Café brings the delight of a boutique coffee shop experience to your living room. Make the moment special."
+    },
+    "howItWorks": {
+      "title": "How It Works (3 Simple Steps)",
+      "step1Title": "1. Build Your Menu",
+      "step1Text": "Give your café a name. Add your specialties—Latte, Tisane, or Tartine. Customize options for milk and sugar.",
+      "step2Title": "2. Share the Link",
+      "step2Text": "Print your QR code for the fridge or text the link. Guests browse and customize their beverage exactly how they like it.",
+      "step3Title": "3. Get Notified & Serve",
+      "step3Text": "Ding! You get a notification instantly. No money changes hands—just a perfect cup served with a smile."
+    },
+    "features": {
+      "title": "Features",
+      "feature1Title": "Fully Customizable Menu",
+      "feature1Text": "From \"Tisane d'allaitement\" to \"Iced Matcha\", you define what you serve.",
+      "feature2Title": "Instant Push Notifications",
+      "feature2Text": "Never miss an order. You'll know the second your \"customer\" submits their request.",
+      "feature3Title": "Zero App Download",
+      "feature3Text": "Guests just scan (or click) and order. No installation needed.",
+      "feature4Title": "Totally Free",
+      "feature4Text": "No payment gateways. The only currency here is gratitude."
+    },
+    "stories": {
+      "title": "Real Stories",
+      "quote1": "Can I use your app to order a tea, dad?",
+      "quote1Name": "Zola, Age 5",
+      "quote1Role": "Chief Taste Tester",
+      "quote2": "It's so much easier to order a coffee for when I get back home. And the barista is super cute too!",
+      "quote2Name": "Magali",
+      "quote2Role": "Wife & Loyal Customer"
+    },
+    "audience": {
+      "title": "Who is My Tiny Café For?",
+      "card1Title": "The Remote Work Power Couple",
+      "card1Text": "Send a silent order for a caffeine boost without interrupting the Zoom meeting.",
+      "card2Title": "The \"Host with the Most\"",
+      "card2Text": "Impress your guests by letting them order their post-meal digestif via a digital menu.",
+      "card3Title": "The Playful Parent",
+      "card3Text": "Kids love playing \"restaurant.\" Set up the menu for them and let them take your order."
+    },
+    "faq": {
+      "title": "FAQ",
+      "q1": "Is it really free?",
+      "a1": "Yes! My Tiny Café is currently completely free to use.",
+      "q2": "Can I charge money for the drinks?",
+      "a2": "No. This app is designed for friends and family. There is no payment processing involved—just the joy of serving a drink to someone you care about.",
+      "q3": "What can I put on the menu?",
+      "a3": "Anything! Coffee, tea, snacks, tartines, water... if you can make it in your kitchen, you can put it on your menu."
+    },
+    "openSource": {
+      "title": "Proudly Open Source",
+      "text": "I believe in transparency and community. My Tiny Café is open source, so you can see exactly how it's built, contribute features, or host it yourself.",
+      "button": "View on GitHub"
+    },
+    "footer": {
+      "title": "Ready to open shop?",
+      "subtitle": "Join the community of home baristas today.",
+      "cta": "Create Your Café Now",
+      "madeWith": "Made with ❤️ in France for Zola and Magali.",
+      "copyright": "© 2024 My Tiny Café",
+      "aboutMakerTitle": "About the Maker",
+      "aboutMakerText": "I am Alix, I built this to make my wife and daughter happy. I hope it brings a little joy to your home too. I am a freelance frontend developer (preferably in Vue.js / Nuxt.js) with a background in Human-Computer Interaction research. {link}.",
+      "aboutMakerLink": "Check out my work",
+      "guest": "Guest?",
+      "findCafe": "Find a Café"
+    }
+  },
+  "auth": {
+    "fields": {
+      "emailLabel": "Email",
+      "emailPlaceholder": "you{'@'}example.com",
+      "emailFloating": "Email",
+      "passwordLabel": "Password",
+      "passwordFloating": "Password",
+      "nameLabel": "Name",
+      "namePlaceholder": "Your Name",
+      "nameFloating": "Your name",
+      "cafeIdLabel": "Café ID",
+      "cafeIdPlaceholder": "Café ID",
+      "cafeIdFloating": "Your café ID"
+    },
+    "validation": {
+      "invalidEmail": "Invalid email address",
+      "passwordMin": "Password must be at least 8 characters",
+      "nameMin": "Name must be at least 2 characters",
+      "cafeIdMin": "Cafe ID must be at least 3 characters"
+    },
+    "login": {
+      "title": "Login",
+      "submit": "Login",
+      "noAccount": "Don't have an account?",
+      "signupLink": "Sign up",
+      "successTitle": "Login Successful!",
+      "successDesc": "Redirecting...",
+      "failTitle": "Login Failed",
+      "errorUnexpected": "An unexpected error occurred. Please try again."
+    },
+    "signup": {
+      "title": "Create Account",
+      "submit": "Sign Up",
+      "haveAccount": "Already have an account?",
+      "loginLink": "Log In",
+      "accountCreatedTitle": "Account Created!",
+      "accountCreatedDesc": "Please login to continue.",
+      "invalidCafeIdTitle": "Invalid Cafe ID",
+      "invalidCafeIdDesc": "Cafe ID cannot be \"undefined\". Please choose a different cafe ID.",
+      "cafeIdExistsTitle": "Cafe ID already exists",
+      "cafeIdExistsDesc": "Please choose a different cafe ID.",
+      "failTitle": "Signup Failed",
+      "failDesc": "An unexpected error occurred."
+    }
+  },
+  "setup": {
+    "title": "Complete Cafe Setup",
+    "intro": "It seems something went wrong during the setup of your cafe. Please provide your cafe details to continue.",
+    "cafeNameLabel": "Cafe Name",
+    "cafeNamePlaceholder": "My Awesome Cafe",
+    "cafeNameFloating": "Cafe Name",
+    "noSpecialChars": "Your café name cannot contain special characters or spaces.",
+    "cafeIdLabel": "Café ID",
+    "cafeIdPlaceholder": "cafe-id",
+    "cafeIdFloating": "Your café ID",
+    "submit": "Complete Setup",
+    "cafeFoundTitle": "Cafe Found",
+    "cafeFoundDesc": "Redirecting to your cafe...",
+    "authErrorTitle": "Authentication Error",
+    "authErrorDesc": "You need to be logged in to complete setup.",
+    "cafeIdExistsTitle": "Cafe ID already exists",
+    "cafeIdExistsDesc": "Please choose a different cafe ID.",
+    "invalidCafeIdTitle": "Invalid Cafe ID",
+    "invalidCafeIdDesc": "Cafe ID cannot be \"undefined\". Please choose a different cafe ID.",
+    "completeTitle": "Setup Complete!",
+    "completeDesc": "Your cafe is ready.",
+    "failTitle": "Setup Failed",
+    "failDesc": "An unexpected error occurred.",
+    "validation": {
+      "nameMin": "Name must be at least 2 characters",
+      "cafeIdMin": "Cafe ID must be at least 3 characters"
+    }
+  },
+  "menu": {
+    "beBarista": "Be the barista",
+    "heading": "Menu",
+    "pastOrders": "Past Orders",
+    "unknownItem": "Unknown item",
+    "yourName": "Your name",
+    "order": "Order",
+    "anonymous": "Anon",
+    "status": {
+      "ordered": "Your order is being prepared",
+      "completed": "Your order is ready !",
+      "canceled": "Your order has been canceled",
+      "unknown": "Unknown status"
+    },
+    "toast": {
+      "orderSentTitle": "Order sent",
+      "orderSentDesc": "Your order has been sent successfully.",
+      "errorTitle": "Error",
+      "orderFailDesc": "Failed to send your order. Please try again.",
+      "orderCanceledTitle": "Order canceled",
+      "orderCanceledDesc": "Your order has been canceled successfully.",
+      "cancelFailDesc": "Failed to cancel your order. Please try again."
+    },
+    "headDescription": "Order your favorite items from {cafeName}"
+  },
+  "baristaOrders": {
+    "title": "Order",
+    "enableNotifications": "Receive a notification when a new order is placed",
+    "emptyTitle": "No orders yet",
+    "emptyText": "Share your café page to start receiving orders!",
+    "shareCafe": "Share my Café",
+    "pastOrders": "Past Orders",
+    "cancel": "Cancel",
+    "complete": "Complete",
+    "unknownItem": "Unknown item",
+    "statusLabel": {
+      "ordered": "Ordered",
+      "completed": "Completed",
+      "canceled": "Canceled"
+    }
+  },
+  "baristaMenu": {
+    "manageMenuFor": "Manage Menu for {cafeName}",
+    "cafeId": "Cafe ID: {id}",
+    "addNewItem": "Add New Item",
+    "noItemsTitle": "No items yet",
+    "noItemsText": "Get started by adding a new menu item.",
+    "options": "Options:",
+    "yesNo": "Yes / No",
+    "noOptions": "No specific options defined.",
+    "edit": "Edit",
+    "delete": "Delete",
+    "editItemTitle": "Edit {name}",
+    "addItemTitle": "Add New Item",
+    "itemNamePlaceholder": "e.g., Espresso, Croissant",
+    "itemNameFloating": "Item name",
+    "pricePlaceholder": "e.g., 3.50",
+    "priceFloating": "Price",
+    "imageLabel": "Image",
+    "noImage": "No image",
+    "descriptionPlaceholder": "Item description...",
+    "descriptionFloating": "Description",
+    "optionNamePlaceholder": "e.g., Size, Milk, Decaf",
+    "optionNameFloating": "Option name",
+    "multipleValues": "Multiple Values / Simple option",
+    "valuesFor": "Values for {name}:",
+    "thisOption": "this option",
+    "valuePlaceholder": "e.g., Small, Large, Oat Milk",
+    "valueFloating": "Value",
+    "addValue": "Add Value",
+    "addNewOptionType": "Add New Option Type",
+    "removeOption": "Remove option",
+    "removeValue": "Remove value",
+    "cancel": "Cancel",
+    "saveChanges": "Save Changes",
+    "addItem": "Add Item",
+    "confirmDelete": "Are you sure you want to delete this item? This action cannot be undone.",
+    "images": {
+      "bobba": "Bubble tea",
+      "cafe": "Coffee",
+      "cookie": "Cookie",
+      "emporter": "Takeaway",
+      "gaiwan": "Gaiwan",
+      "jus": "Juice",
+      "latte": "Latte",
+      "muffin": "Muffin",
+      "mug": "Mug",
+      "tartine": "Tartine",
+      "the": "Tea",
+      "yaourt": "Yogurt"
+    },
+    "toast": {
+      "errorLoadingCafeTitle": "Error Loading Cafe",
+      "errorLoadingCafeDesc": "The requested cafe could not be found or loaded.",
+      "errorLoadingMenuTitle": "Error Loading Menu",
+      "errorLoadingMenuDesc": "Could not load menu items.",
+      "errorTitle": "Error",
+      "cafeIdMissing": "Cafe ID is missing.",
+      "itemDeletedTitle": "Item Deleted",
+      "itemDeletedDesc": "The item has been successfully deleted.",
+      "deletionFailedTitle": "Deletion Failed",
+      "deletionFailedDesc": "Could not delete the item.",
+      "validationErrorTitle": "Validation Error",
+      "itemNameRequired": "Item name is required.",
+      "itemUpdatedTitle": "Item Updated",
+      "itemUpdatedDesc": "Changes saved successfully.",
+      "itemAddedTitle": "Item Added",
+      "itemAddedDesc": "New item added to the menu.",
+      "saveFailedTitle": "Save Failed",
+      "saveFailedDesc": "Could not save the item."
+    }
+  },
+  "cafeSettings": {
+    "share": {
+      "title": "Share Your Page",
+      "subtitle": "Share this page using the URL or QR code below.",
+      "pageUrlLabel": "Page URL",
+      "pageUrlHelp": "This is the direct link to your page.",
+      "generatingUrl": "Generating URL..."
+    },
+    "qr": {
+      "title": "QR Code",
+      "subtitle": "Scan this QR code with a mobile device to open the page.",
+      "downloadPng": "Download PNG",
+      "unavailable": "Page URL not available, QR code cannot be generated."
+    },
+    "updateName": {
+      "title": "Update Cafe Name",
+      "subtitle": "Modify your cafe's name.",
+      "label": "Cafe Name",
+      "help": "Enter the new name for your cafe.",
+      "placeholder": "Enter new cafe name",
+      "update": "Update",
+      "updating": "Updating..."
+    },
+    "customImages": {
+      "title": "Custom Images",
+      "subtitle": "Upload your own images to use in your menu items.",
+      "upload": "Upload Image",
+      "empty": "No custom images yet. Upload one to get started."
+    },
+    "about": {
+      "title": "About & Support",
+      "openSourceTitle": "Open Source",
+      "openSourceText": "This project is somewhat open source. The appwrite server configuration available on Github is probably outdated, reach out if you need anything.",
+      "viewOnGithub": "View on GitHub",
+      "contactTitle": "Contact the Maker",
+      "contactText": "Built by Alix. Reach out if you need anything.",
+      "hireText": "What about hiring me for your next project ?",
+      "supportTitle": "Support My Tiny Café",
+      "supportText": "My Tiny Café is available free of charge, but if you enjoy using it, consider supporting its hosting costs.",
+      "supportButton": "Support on Buy Me a Coffee"
+    },
+    "delete": {
+      "title": "Delete Account",
+      "subtitle": "Permanently delete your café, its menu, all orders, any custom images, and your account. This action cannot be undone.",
+      "button": "Delete my account",
+      "modalTitle": "Delete your account permanently?",
+      "modalIntro": "This will permanently delete:",
+      "modalListCafe": "your café {id}",
+      "modalListMenu": "its menu items and all past orders",
+      "modalListImages": "your custom images",
+      "modalListAccount": "your account (you will not be able to log in again)",
+      "confirmLabel": "Type \"{cafeId}\" to confirm",
+      "deletePermanently": "Delete permanently"
+    },
+    "session": {
+      "title": "Session",
+      "subtitle": "Sign out of this device. You can sign back in anytime.",
+      "logout": "Logout"
+    },
+    "toast": {
+      "imageUploadedTitle": "Image Uploaded",
+      "imageUploadedDesc": "\"{name}\" has been uploaded.",
+      "uploadFailedTitle": "Upload Failed",
+      "uploadFailedDesc": "Could not upload the image.",
+      "confirmDeleteImage": "Delete this image? Items using it will show a broken image.",
+      "imageDeletedTitle": "Image Deleted",
+      "imageDeletedDesc": "The image has been deleted.",
+      "deleteFailedTitle": "Delete Failed",
+      "deleteFailedDesc": "Could not delete the image.",
+      "errorTitle": "Error",
+      "cafeIdUnavailable": "Cafe ID is not available. Cannot update name.",
+      "validationErrorTitle": "Validation Error",
+      "cafeNameEmpty": "Cafe name cannot be empty.",
+      "successTitle": "Success!",
+      "cafeNameUpdated": "Cafe name updated to \"{name}\".",
+      "updateFailedTitle": "Update Failed",
+      "updateNameFailedDesc": "Could not update cafe name. Please try again.",
+      "missingCafeIdTitle": "Missing Cafe ID",
+      "missingCafeIdDesc": "The unique identifier for the cafe is missing from the URL.",
+      "urlNotAvailableTitle": "URL Not Available",
+      "urlNotAvailableDesc": "The page URL is not ready to be copied.",
+      "clipboardDeniedTitle": "Clipboard Access Denied",
+      "clipboardDeniedDesc": "Your browser settings prevent clipboard access, or it's not supported.",
+      "urlCopiedTitle": "URL Copied!",
+      "urlCopiedDesc": "The page URL has been copied to your clipboard.",
+      "copyUnconfirmedTitle": "Copy Unconfirmed",
+      "copyUnconfirmedDesc": "Attempted to copy. Please verify your clipboard.",
+      "copyFailedTitle": "Copy Failed",
+      "copyFailedDesc": "An error occurred while trying to copy the URL. Please copy it manually.",
+      "downloadFailedTitle": "Download Failed",
+      "qrNotReady": "QR code is not ready yet. Please try again.",
+      "qrDownloadedTitle": "QR Code Downloaded",
+      "qrDownloadedDesc": "The QR code PNG has been saved.",
+      "qrGenerateFailed": "Could not generate the PNG file. Please try again.",
+      "loggedOutTitle": "Logged out",
+      "loggedOutDesc": "You have been logged out",
+      "accountDeletedTitle": "Account deleted",
+      "accountDeletedDesc": "Your account and café have been permanently deleted.",
+      "deletionFailedTitle": "Deletion Failed",
+      "deletionFailedDesc": "Could not delete your account. Please try again."
+    }
+  },
+  "invalidCafe": {
+    "title": "This café is closed.",
+    "text": "We couldn't find any café at this address. Maybe the link is wrong — or maybe it's time for {you} to open your own?",
+    "textHighlight": "you",
+    "openOwn": "Open my own café",
+    "backHome": "Back home",
+    "noCreditCard": "No credit card. No ads. Just love.",
+    "headTitle": "Café not found — My Tiny Café"
+  },
+  "pwa": {
+    "finding": "Finding your spot...",
+    "redirecting": "Redirecting you to your last visited café."
+  },
+  "demo": {
+    "cafeName": "Chez Zola",
+    "promptTitle": "Want your own home café?",
+    "promptText": "If you'd love to open your own tiny café for friends and family, sign up — it's totally free, ad-free, and takes about a minute.",
+    "openCafe": "Open my tiny café",
+    "keepBrowsing": "Keep browsing",
+    "items": {
+      "latte": {
+        "name": "Latte",
+        "description": "Silky espresso topped with steamed milk.",
+        "price": "1 hug 🤗"
+      },
+      "espresso": {
+        "name": "Espresso",
+        "description": "Short, dark, intense. The classic."
+      },
+      "matcha": {
+        "name": "Matcha",
+        "description": "Whisked ceremonial-grade green tea."
+      },
+      "tea": {
+        "name": "Tea",
+        "description": "Loose-leaf, steeped to order."
+      },
+      "juice": {
+        "name": "Fresh Juice",
+        "description": "Pressed this morning."
+      },
+      "bubble": {
+        "name": "Bubble Tea",
+        "description": "Chewy tapioca, your favorite flavor."
+      },
+      "muffin": {
+        "name": "Muffin",
+        "description": "Baked this morning."
+      },
+      "cookie": {
+        "name": "Cookie",
+        "description": "Warm and chewy."
+      },
+      "tartine": {
+        "name": "Tartine",
+        "description": "Sourdough, toasted, with toppings."
+      },
+      "yogurt": {
+        "name": "Yogurt",
+        "description": "Greek yogurt, fresh fruits, granola.",
+        "price": "Free!"
+      }
+    }
+  }
+}

--- a/i18n/locales/es.json
+++ b/i18n/locales/es.json
@@ -1,0 +1,475 @@
+{
+  "common": {
+    "cancel": "Cancelar",
+    "save": "Guardar",
+    "delete": "Eliminar",
+    "edit": "Editar",
+    "close": "Cerrar",
+    "copy": "Copiar",
+    "copied": "¡Copiado!",
+    "loading": "Cargando..."
+  },
+  "nav": {
+    "orders": "Pedidos",
+    "menu": "Menú",
+    "cafe": "Café"
+  },
+  "languageSwitcher": {
+    "label": "Idioma"
+  },
+  "app": {
+    "name": "My Tiny Café",
+    "description": "Pide en tu café favorito"
+  },
+  "landing": {
+    "nav": {
+      "login": "Iniciar sesión",
+      "openCafe": "Abrir mi My Tiny Café"
+    },
+    "hero": {
+      "title": "Convierte tu casa en la {highlight} del barrio.",
+      "titleHighlight": "Mejor Cafetería",
+      "subtitle": "El menú digital para baristas caseros. Crea tu carta de bebidas, comparte tu código QR con amigos y familia, y recibe los pedidos directamente en tu móvil.",
+      "subtitleEmphasis": "100 % Gratis. 100 % Acogedor.",
+      "ctaPrimary": "Abrir mi My Tiny Café",
+      "ctaDemo": "Ver un café de demostración ↗",
+      "noCreditCard": "Sin tarjeta de crédito. Sin anuncios. Solo amor."
+    },
+    "mockup": {
+      "notifTitle": "Nuevo pedido de Magali",
+      "notifOrder": "Latte (Leche de avena, Sin azúcar)",
+      "now": "ahora",
+      "menu": "Menú",
+      "latte": "Latte",
+      "lattePrice": "1 abrazo 🤗",
+      "matcha": "Matcha",
+      "tea": "Té",
+      "teaPrice": "Un cuento 📖",
+      "cookie": "Galleta",
+      "cookiePrice": "¡Gratis!"
+    },
+    "valueProp": {
+      "eyebrow": "Hospitalidad, mejorada",
+      "heading": "¿Por qué gritar desde la cocina?",
+      "problemTitle": "El problema",
+      "problemText": "Gritar desde la cocina «¿Quién quiere té?» y olvidar quién quería azúcar y quién leche de almendra para cuando hierve el agua.",
+      "solutionTitle": "La solución",
+      "solutionText": "My Tiny Café trae el encanto de una cafetería boutique a tu salón. Haz que el momento sea especial."
+    },
+    "howItWorks": {
+      "title": "Cómo funciona (3 pasos sencillos)",
+      "step1Title": "1. Crea tu menú",
+      "step1Text": "Ponle nombre a tu café. Añade tus especialidades: Latte, Tisana o Tostada. Personaliza las opciones de leche y azúcar.",
+      "step2Title": "2. Comparte el enlace",
+      "step2Text": "Imprime tu código QR para la nevera o envía el enlace por mensaje. Tus invitados navegan y personalizan su bebida justo como les gusta.",
+      "step3Title": "3. Recibe el aviso y sirve",
+      "step3Text": "¡Ding! Recibes una notificación al instante. Sin que medie dinero: solo una taza perfecta servida con una sonrisa."
+    },
+    "features": {
+      "title": "Características",
+      "feature1Title": "Menú totalmente personalizable",
+      "feature1Text": "Desde la «Tisana de lactancia» hasta el «Matcha helado», tú defines lo que sirves.",
+      "feature2Title": "Notificaciones push instantáneas",
+      "feature2Text": "No te pierdas ningún pedido. Te enterarás en el segundo en que tu «cliente» envíe su petición.",
+      "feature3Title": "Sin descargar ninguna app",
+      "feature3Text": "Tus invitados solo escanean (o hacen clic) y piden. Sin instalar nada.",
+      "feature4Title": "Totalmente gratis",
+      "feature4Text": "Sin pasarelas de pago. Aquí la única moneda es la gratitud."
+    },
+    "stories": {
+      "title": "Historias reales",
+      "quote1": "Papá, ¿puedo usar tu app para pedir un té?",
+      "quote1Name": "Zola, 5 años",
+      "quote1Role": "Jefa de cata",
+      "quote2": "Es mucho más fácil pedir un café para cuando vuelvo a casa. ¡Y el barista es supermono también!",
+      "quote2Name": "Magali",
+      "quote2Role": "Esposa y clienta fiel"
+    },
+    "audience": {
+      "title": "¿Para quién es My Tiny Café?",
+      "card1Title": "La pareja teletrabajadora con ritmo",
+      "card1Text": "Envía un pedido silencioso para una dosis de cafeína sin interrumpir la reunión de Zoom.",
+      "card2Title": "El «anfitrión de los anfitriones»",
+      "card2Text": "Impresiona a tus invitados dejándoles pedir su digestivo de sobremesa con un menú digital.",
+      "card3Title": "El padre o la madre con ganas de jugar",
+      "card3Text": "A los peques les encanta jugar a los «restaurantes». Prepárales el menú y deja que te tomen nota."
+    },
+    "faq": {
+      "title": "Preguntas frecuentes",
+      "q1": "¿De verdad es gratis?",
+      "a1": "¡Sí! My Tiny Café es ahora mismo totalmente gratuito.",
+      "q2": "¿Puedo cobrar dinero por las bebidas?",
+      "a2": "No. Esta app está pensada para amigos y familia. No hay ningún procesamiento de pagos: solo la alegría de servir una bebida a alguien que te importa.",
+      "q3": "¿Qué puedo poner en el menú?",
+      "a3": "¡Lo que quieras! Café, té, aperitivos, tostadas, agua... si puedes prepararlo en tu cocina, puedes ponerlo en tu menú."
+    },
+    "openSource": {
+      "title": "Orgullosamente de código abierto",
+      "text": "Creo en la transparencia y en la comunidad. My Tiny Café es de código abierto, así que puedes ver exactamente cómo está hecho, contribuir con funciones o alojarlo tú mismo.",
+      "button": "Ver en GitHub"
+    },
+    "footer": {
+      "title": "¿Listo para abrir tu café?",
+      "subtitle": "Únete hoy a la comunidad de baristas caseros.",
+      "cta": "Crea tu café ahora",
+      "madeWith": "Hecho con ❤️ en Francia para Zola y Magali.",
+      "copyright": "© 2024 My Tiny Café",
+      "aboutMakerTitle": "Sobre el creador",
+      "aboutMakerText": "Soy Alix, y creé esto para hacer felices a mi mujer y a mi hija. Espero que traiga también un poquito de alegría a tu hogar. Soy desarrollador frontend freelance (preferiblemente en Vue.js / Nuxt.js) con experiencia en investigación de Interacción Persona-Ordenador. {link}.",
+      "aboutMakerLink": "Echa un vistazo a mi trabajo",
+      "guest": "¿Invitado?",
+      "findCafe": "Buscar un café"
+    }
+  },
+  "auth": {
+    "fields": {
+      "emailLabel": "Correo electrónico",
+      "emailPlaceholder": "tu{'@'}ejemplo.com",
+      "emailFloating": "Correo electrónico",
+      "passwordLabel": "Contraseña",
+      "passwordFloating": "Contraseña",
+      "nameLabel": "Nombre",
+      "namePlaceholder": "Tu nombre",
+      "nameFloating": "Tu nombre",
+      "cafeIdLabel": "ID del café",
+      "cafeIdPlaceholder": "ID del café",
+      "cafeIdFloating": "El ID de tu café"
+    },
+    "validation": {
+      "invalidEmail": "Dirección de correo no válida",
+      "passwordMin": "La contraseña debe tener al menos 8 caracteres",
+      "nameMin": "El nombre debe tener al menos 2 caracteres",
+      "cafeIdMin": "El ID del café debe tener al menos 3 caracteres"
+    },
+    "login": {
+      "title": "Iniciar sesión",
+      "submit": "Iniciar sesión",
+      "noAccount": "¿No tienes cuenta?",
+      "signupLink": "Regístrate",
+      "successTitle": "¡Sesión iniciada!",
+      "successDesc": "Redirigiendo...",
+      "failTitle": "Error al iniciar sesión",
+      "errorUnexpected": "Se ha producido un error inesperado. Inténtalo de nuevo."
+    },
+    "signup": {
+      "title": "Crear cuenta",
+      "submit": "Registrarse",
+      "haveAccount": "¿Ya tienes cuenta?",
+      "loginLink": "Iniciar sesión",
+      "accountCreatedTitle": "¡Cuenta creada!",
+      "accountCreatedDesc": "Inicia sesión para continuar.",
+      "invalidCafeIdTitle": "ID del café no válido",
+      "invalidCafeIdDesc": "El ID del café no puede ser «undefined». Elige un ID de café diferente.",
+      "cafeIdExistsTitle": "El ID del café ya existe",
+      "cafeIdExistsDesc": "Elige un ID de café diferente.",
+      "failTitle": "Error en el registro",
+      "failDesc": "Se ha producido un error inesperado."
+    }
+  },
+  "setup": {
+    "title": "Completar la configuración del café",
+    "intro": "Parece que algo salió mal durante la configuración de tu café. Indica los datos de tu café para continuar.",
+    "cafeNameLabel": "Nombre del café",
+    "cafeNamePlaceholder": "Mi café estupendo",
+    "cafeNameFloating": "Nombre del café",
+    "noSpecialChars": "El nombre de tu café no puede contener caracteres especiales ni espacios.",
+    "cafeIdLabel": "ID del café",
+    "cafeIdPlaceholder": "id-del-cafe",
+    "cafeIdFloating": "El ID de tu café",
+    "submit": "Completar configuración",
+    "cafeFoundTitle": "Café encontrado",
+    "cafeFoundDesc": "Redirigiendo a tu café...",
+    "authErrorTitle": "Error de autenticación",
+    "authErrorDesc": "Tienes que haber iniciado sesión para completar la configuración.",
+    "cafeIdExistsTitle": "El ID del café ya existe",
+    "cafeIdExistsDesc": "Elige un ID de café diferente.",
+    "invalidCafeIdTitle": "ID del café no válido",
+    "invalidCafeIdDesc": "El ID del café no puede ser «undefined». Elige un ID de café diferente.",
+    "completeTitle": "¡Configuración completada!",
+    "completeDesc": "Tu café está listo.",
+    "failTitle": "Error en la configuración",
+    "failDesc": "Se ha producido un error inesperado.",
+    "validation": {
+      "nameMin": "El nombre debe tener al menos 2 caracteres",
+      "cafeIdMin": "El ID del café debe tener al menos 3 caracteres"
+    }
+  },
+  "menu": {
+    "beBarista": "Sé el barista",
+    "heading": "Menú",
+    "pastOrders": "Pedidos anteriores",
+    "unknownItem": "Artículo desconocido",
+    "yourName": "Tu nombre",
+    "order": "Pedir",
+    "anonymous": "Anón.",
+    "status": {
+      "ordered": "Tu pedido se está preparando",
+      "completed": "¡Tu pedido está listo!",
+      "canceled": "Tu pedido ha sido cancelado",
+      "unknown": "Estado desconocido"
+    },
+    "toast": {
+      "orderSentTitle": "Pedido enviado",
+      "orderSentDesc": "Tu pedido se ha enviado correctamente.",
+      "errorTitle": "Error",
+      "orderFailDesc": "No se pudo enviar tu pedido. Inténtalo de nuevo.",
+      "orderCanceledTitle": "Pedido cancelado",
+      "orderCanceledDesc": "Tu pedido se ha cancelado correctamente.",
+      "cancelFailDesc": "No se pudo cancelar tu pedido. Inténtalo de nuevo."
+    },
+    "headDescription": "Pide tus artículos favoritos de {cafeName}"
+  },
+  "baristaOrders": {
+    "title": "Pedido",
+    "enableNotifications": "Recibe una notificación cuando se haga un nuevo pedido",
+    "emptyTitle": "Aún no hay pedidos",
+    "emptyText": "¡Comparte la página de tu café para empezar a recibir pedidos!",
+    "shareCafe": "Compartir mi café",
+    "pastOrders": "Pedidos anteriores",
+    "cancel": "Cancelar",
+    "complete": "Completar",
+    "unknownItem": "Artículo desconocido",
+    "statusLabel": {
+      "ordered": "Pedido",
+      "completed": "Completado",
+      "canceled": "Cancelado"
+    }
+  },
+  "baristaMenu": {
+    "manageMenuFor": "Gestionar el menú de {cafeName}",
+    "cafeId": "ID del café: {id}",
+    "addNewItem": "Añadir nuevo artículo",
+    "noItemsTitle": "Aún no hay artículos",
+    "noItemsText": "Empieza añadiendo un nuevo artículo al menú.",
+    "options": "Opciones:",
+    "yesNo": "Sí / No",
+    "noOptions": "No hay opciones específicas definidas.",
+    "edit": "Editar",
+    "delete": "Eliminar",
+    "editItemTitle": "Editar {name}",
+    "addItemTitle": "Añadir nuevo artículo",
+    "itemNamePlaceholder": "p. ej., Espresso, Croissant",
+    "itemNameFloating": "Nombre del artículo",
+    "pricePlaceholder": "p. ej., 3,50",
+    "priceFloating": "Precio",
+    "imageLabel": "Imagen",
+    "noImage": "Sin imagen",
+    "descriptionPlaceholder": "Descripción del artículo...",
+    "descriptionFloating": "Descripción",
+    "optionNamePlaceholder": "p. ej., Tamaño, Leche, Descafeinado",
+    "optionNameFloating": "Nombre de la opción",
+    "multipleValues": "Varios valores / Opción simple",
+    "valuesFor": "Valores de {name}:",
+    "thisOption": "esta opción",
+    "valuePlaceholder": "p. ej., Pequeño, Grande, Leche de avena",
+    "valueFloating": "Valor",
+    "addValue": "Añadir valor",
+    "addNewOptionType": "Añadir nuevo tipo de opción",
+    "removeOption": "Quitar opción",
+    "removeValue": "Quitar valor",
+    "cancel": "Cancelar",
+    "saveChanges": "Guardar cambios",
+    "addItem": "Añadir artículo",
+    "confirmDelete": "¿Seguro que quieres eliminar este artículo? Esta acción no se puede deshacer.",
+    "images": {
+      "bobba": "Bubble tea",
+      "cafe": "Café",
+      "cookie": "Galleta",
+      "emporter": "Para llevar",
+      "gaiwan": "Gaiwan",
+      "jus": "Zumo",
+      "latte": "Latte",
+      "muffin": "Magdalena",
+      "mug": "Taza",
+      "tartine": "Tostada",
+      "the": "Té",
+      "yaourt": "Yogur"
+    },
+    "toast": {
+      "errorLoadingCafeTitle": "Error al cargar el café",
+      "errorLoadingCafeDesc": "No se ha podido encontrar ni cargar el café solicitado.",
+      "errorLoadingMenuTitle": "Error al cargar el menú",
+      "errorLoadingMenuDesc": "No se pudieron cargar los artículos del menú.",
+      "errorTitle": "Error",
+      "cafeIdMissing": "Falta el ID del café.",
+      "itemDeletedTitle": "Artículo eliminado",
+      "itemDeletedDesc": "El artículo se ha eliminado correctamente.",
+      "deletionFailedTitle": "Error al eliminar",
+      "deletionFailedDesc": "No se pudo eliminar el artículo.",
+      "validationErrorTitle": "Error de validación",
+      "itemNameRequired": "El nombre del artículo es obligatorio.",
+      "itemUpdatedTitle": "Artículo actualizado",
+      "itemUpdatedDesc": "Cambios guardados correctamente.",
+      "itemAddedTitle": "Artículo añadido",
+      "itemAddedDesc": "Nuevo artículo añadido al menú.",
+      "saveFailedTitle": "Error al guardar",
+      "saveFailedDesc": "No se pudo guardar el artículo."
+    }
+  },
+  "cafeSettings": {
+    "share": {
+      "title": "Comparte tu página",
+      "subtitle": "Comparte esta página con la URL o el código QR de abajo.",
+      "pageUrlLabel": "URL de la página",
+      "pageUrlHelp": "Este es el enlace directo a tu página.",
+      "generatingUrl": "Generando URL..."
+    },
+    "qr": {
+      "title": "Código QR",
+      "subtitle": "Escanea este código QR con un móvil para abrir la página.",
+      "downloadPng": "Descargar PNG",
+      "unavailable": "La URL de la página no está disponible, no se puede generar el código QR."
+    },
+    "updateName": {
+      "title": "Actualizar el nombre del café",
+      "subtitle": "Modifica el nombre de tu café.",
+      "label": "Nombre del café",
+      "help": "Introduce el nuevo nombre de tu café.",
+      "placeholder": "Introduce el nuevo nombre del café",
+      "update": "Actualizar",
+      "updating": "Actualizando..."
+    },
+    "customImages": {
+      "title": "Imágenes personalizadas",
+      "subtitle": "Sube tus propias imágenes para usarlas en los artículos de tu menú.",
+      "upload": "Subir imagen",
+      "empty": "Aún no hay imágenes personalizadas. Sube una para empezar."
+    },
+    "about": {
+      "title": "Acerca de y soporte",
+      "openSourceTitle": "Código abierto",
+      "openSourceText": "Este proyecto es en cierto modo de código abierto. La configuración del servidor de Appwrite disponible en GitHub probablemente esté desactualizada; escríbeme si necesitas algo.",
+      "viewOnGithub": "Ver en GitHub",
+      "contactTitle": "Contactar con el creador",
+      "contactText": "Creado por Alix. Escríbeme si necesitas algo.",
+      "hireText": "¿Y si me contratas para tu próximo proyecto?",
+      "supportTitle": "Apoya a My Tiny Café",
+      "supportText": "My Tiny Café está disponible de forma gratuita, pero si te gusta usarlo, plantéate ayudar con sus costes de alojamiento.",
+      "supportButton": "Apóyame en Buy Me a Coffee"
+    },
+    "delete": {
+      "title": "Eliminar cuenta",
+      "subtitle": "Elimina de forma permanente tu café, su menú, todos los pedidos, cualquier imagen personalizada y tu cuenta. Esta acción no se puede deshacer.",
+      "button": "Eliminar mi cuenta",
+      "modalTitle": "¿Eliminar tu cuenta de forma permanente?",
+      "modalIntro": "Esto eliminará de forma permanente:",
+      "modalListCafe": "tu café {id}",
+      "modalListMenu": "los artículos de su menú y todos los pedidos anteriores",
+      "modalListImages": "tus imágenes personalizadas",
+      "modalListAccount": "tu cuenta (no podrás volver a iniciar sesión)",
+      "confirmLabel": "Escribe «{cafeId}» para confirmar",
+      "deletePermanently": "Eliminar de forma permanente"
+    },
+    "session": {
+      "title": "Sesión",
+      "subtitle": "Cierra sesión en este dispositivo. Puedes volver a iniciar sesión cuando quieras.",
+      "logout": "Cerrar sesión"
+    },
+    "toast": {
+      "imageUploadedTitle": "Imagen subida",
+      "imageUploadedDesc": "«{name}» se ha subido.",
+      "uploadFailedTitle": "Error al subir",
+      "uploadFailedDesc": "No se pudo subir la imagen.",
+      "confirmDeleteImage": "¿Eliminar esta imagen? Los artículos que la usen mostrarán una imagen rota.",
+      "imageDeletedTitle": "Imagen eliminada",
+      "imageDeletedDesc": "La imagen se ha eliminado.",
+      "deleteFailedTitle": "Error al eliminar",
+      "deleteFailedDesc": "No se pudo eliminar la imagen.",
+      "errorTitle": "Error",
+      "cafeIdUnavailable": "El ID del café no está disponible. No se puede actualizar el nombre.",
+      "validationErrorTitle": "Error de validación",
+      "cafeNameEmpty": "El nombre del café no puede estar vacío.",
+      "successTitle": "¡Listo!",
+      "cafeNameUpdated": "El nombre del café se ha cambiado a «{name}».",
+      "updateFailedTitle": "Error al actualizar",
+      "updateNameFailedDesc": "No se pudo actualizar el nombre del café. Inténtalo de nuevo.",
+      "missingCafeIdTitle": "Falta el ID del café",
+      "missingCafeIdDesc": "Falta el identificador único del café en la URL.",
+      "urlNotAvailableTitle": "URL no disponible",
+      "urlNotAvailableDesc": "La URL de la página no está lista para copiarse.",
+      "clipboardDeniedTitle": "Acceso al portapapeles denegado",
+      "clipboardDeniedDesc": "La configuración de tu navegador impide el acceso al portapapeles, o no es compatible.",
+      "urlCopiedTitle": "¡URL copiada!",
+      "urlCopiedDesc": "La URL de la página se ha copiado en tu portapapeles.",
+      "copyUnconfirmedTitle": "Copia sin confirmar",
+      "copyUnconfirmedDesc": "Se intentó copiar. Comprueba tu portapapeles.",
+      "copyFailedTitle": "Error al copiar",
+      "copyFailedDesc": "Se produjo un error al intentar copiar la URL. Cópiala manualmente.",
+      "downloadFailedTitle": "Error en la descarga",
+      "qrNotReady": "El código QR aún no está listo. Inténtalo de nuevo.",
+      "qrDownloadedTitle": "Código QR descargado",
+      "qrDownloadedDesc": "Se ha guardado el PNG del código QR.",
+      "qrGenerateFailed": "No se pudo generar el archivo PNG. Inténtalo de nuevo.",
+      "loggedOutTitle": "Sesión cerrada",
+      "loggedOutDesc": "Has cerrado sesión",
+      "accountDeletedTitle": "Cuenta eliminada",
+      "accountDeletedDesc": "Tu cuenta y tu café se han eliminado de forma permanente.",
+      "deletionFailedTitle": "Error al eliminar",
+      "deletionFailedDesc": "No se pudo eliminar tu cuenta. Inténtalo de nuevo."
+    }
+  },
+  "invalidCafe": {
+    "title": "Este café está cerrado.",
+    "text": "No hemos podido encontrar ningún café en esta dirección. Puede que el enlace sea incorrecto... ¿o quizá sea hora de que {you} abras el tuyo?",
+    "textHighlight": "tú",
+    "openOwn": "Abrir mi propio café",
+    "backHome": "Volver al inicio",
+    "noCreditCard": "Sin tarjeta de crédito. Sin anuncios. Solo amor.",
+    "headTitle": "Café no encontrado — My Tiny Café"
+  },
+  "pwa": {
+    "finding": "Buscando tu sitio...",
+    "redirecting": "Redirigiéndote al último café que visitaste."
+  },
+  "demo": {
+    "cafeName": "Chez Zola",
+    "promptTitle": "¿Quieres tu propio café en casa?",
+    "promptText": "Si te encantaría abrir tu propio cafecito para amigos y familia, regístrate: es totalmente gratis, sin anuncios, y te lleva alrededor de un minuto.",
+    "openCafe": "Abrir mi cafecito",
+    "keepBrowsing": "Seguir explorando",
+    "items": {
+      "latte": {
+        "name": "Latte",
+        "description": "Espresso sedoso coronado con leche vaporizada.",
+        "price": "1 abrazo 🤗"
+      },
+      "espresso": {
+        "name": "Espresso",
+        "description": "Corto, oscuro, intenso. El clásico."
+      },
+      "matcha": {
+        "name": "Matcha",
+        "description": "Té verde de grado ceremonial batido."
+      },
+      "tea": {
+        "name": "Té",
+        "description": "En hoja suelta, infusionado al momento."
+      },
+      "juice": {
+        "name": "Zumo natural",
+        "description": "Exprimido esta mañana."
+      },
+      "bubble": {
+        "name": "Bubble Tea",
+        "description": "Tapioca masticable, tu sabor favorito."
+      },
+      "muffin": {
+        "name": "Magdalena",
+        "description": "Horneada esta mañana."
+      },
+      "cookie": {
+        "name": "Galleta",
+        "description": "Calentita y tierna."
+      },
+      "tartine": {
+        "name": "Tostada",
+        "description": "Masa madre, tostada, con ingredientes."
+      },
+      "yogurt": {
+        "name": "Yogur",
+        "description": "Yogur griego, fruta fresca, granola.",
+        "price": "¡Gratis!"
+      }
+    }
+  }
+}

--- a/i18n/locales/fr.json
+++ b/i18n/locales/fr.json
@@ -1,0 +1,475 @@
+{
+  "common": {
+    "cancel": "Annuler",
+    "save": "Enregistrer",
+    "delete": "Supprimer",
+    "edit": "Modifier",
+    "close": "Fermer",
+    "copy": "Copier",
+    "copied": "Copié !",
+    "loading": "Chargement…"
+  },
+  "nav": {
+    "orders": "Commandes",
+    "menu": "Menu",
+    "cafe": "Café"
+  },
+  "languageSwitcher": {
+    "label": "Langue"
+  },
+  "app": {
+    "name": "My Tiny Café",
+    "description": "Commandez dans votre café préféré"
+  },
+  "landing": {
+    "nav": {
+      "login": "Connexion",
+      "openCafe": "Ouvrir mon My Tiny Café"
+    },
+    "hero": {
+      "title": "Transformez votre maison en {highlight} du quartier.",
+      "titleHighlight": "meilleur café",
+      "subtitle": "Le menu digital des baristas à domicile. Créez votre carte des boissons, partagez votre QR code avec vos proches et recevez les commandes directement sur votre téléphone.",
+      "subtitleEmphasis": "100 % gratuit. 100 % cosy.",
+      "ctaPrimary": "Ouvrir mon My Tiny Café",
+      "ctaDemo": "Voir un café de démo ↗",
+      "noCreditCard": "Pas de carte bancaire. Pas de pub. Juste de l'amour."
+    },
+    "mockup": {
+      "notifTitle": "Nouvelle commande de Magali",
+      "notifOrder": "Latte (lait d'avoine, sans sucre)",
+      "now": "maintenant",
+      "menu": "Menu",
+      "latte": "Latte",
+      "lattePrice": "1 câlin 🤗",
+      "matcha": "Matcha",
+      "tea": "Thé",
+      "teaPrice": "Une histoire 📖",
+      "cookie": "Cookie",
+      "cookiePrice": "Gratuit !"
+    },
+    "valueProp": {
+      "eyebrow": "L'hospitalité, version premium",
+      "heading": "Pourquoi crier depuis la cuisine ?",
+      "problemTitle": "Le problème",
+      "problemText": "Crier depuis la cuisine « Qui veut du thé ? » et oublier qui voulait du sucre et qui voulait du lait d'amande le temps que la bouilloire chauffe.",
+      "solutionTitle": "La solution",
+      "solutionText": "My Tiny Café apporte tout le charme d'un café de quartier jusque dans votre salon. Faites de ce moment un instant spécial."
+    },
+    "howItWorks": {
+      "title": "Comment ça marche (3 étapes simples)",
+      "step1Title": "1. Composez votre menu",
+      "step1Text": "Donnez un nom à votre café. Ajoutez vos spécialités — Latte, tisane ou tartine. Personnalisez les options de lait et de sucre.",
+      "step2Title": "2. Partagez le lien",
+      "step2Text": "Imprimez votre QR code pour le frigo ou envoyez le lien par message. Vos invités parcourent la carte et personnalisent leur boisson comme ils l'aiment.",
+      "step3Title": "3. Recevez l'alerte et servez",
+      "step3Text": "Ding ! Vous recevez une notification instantanément. Aucun échange d'argent — juste une tasse parfaite servie avec le sourire."
+    },
+    "features": {
+      "title": "Fonctionnalités",
+      "feature1Title": "Menu entièrement personnalisable",
+      "feature1Text": "De la « tisane d'allaitement » au « matcha glacé », c'est vous qui décidez ce que vous servez.",
+      "feature2Title": "Notifications push instantanées",
+      "feature2Text": "Ne ratez plus aucune commande. Vous êtes prévenu dès que votre « client » passe sa demande.",
+      "feature3Title": "Aucune appli à télécharger",
+      "feature3Text": "Vos invités scannent (ou cliquent) et commandent. Aucune installation nécessaire.",
+      "feature4Title": "Entièrement gratuit",
+      "feature4Text": "Pas de paiement en ligne. Ici, la seule monnaie, c'est la gratitude."
+    },
+    "stories": {
+      "title": "Des histoires vraies",
+      "quote1": "Je peux utiliser ton appli pour commander un thé, papa ?",
+      "quote1Name": "Zola, 5 ans",
+      "quote1Role": "Cheffe goûteuse en chef",
+      "quote2": "C'est tellement plus simple de commander un café pour mon retour à la maison. Et le barista est super mignon en plus !",
+      "quote2Name": "Magali",
+      "quote2Role": "Épouse & cliente fidèle"
+    },
+    "audience": {
+      "title": "À qui s'adresse My Tiny Café ?",
+      "card1Title": "Le couple en télétravail",
+      "card1Text": "Passez une commande discrète pour un petit boost de caféine sans interrompre la réunion Zoom.",
+      "card2Title": "L'hôte d'exception",
+      "card2Text": "Épatez vos invités en les laissant commander leur digestif d'après-repas via un menu digital.",
+      "card3Title": "Le parent joueur",
+      "card3Text": "Les enfants adorent jouer au « restaurant ». Configurez le menu pour eux et laissez-les prendre votre commande."
+    },
+    "faq": {
+      "title": "FAQ",
+      "q1": "C'est vraiment gratuit ?",
+      "a1": "Oui ! My Tiny Café est actuellement entièrement gratuit.",
+      "q2": "Puis-je faire payer les boissons ?",
+      "a2": "Non. Cette application est conçue pour les proches et la famille. Aucun paiement n'est géré — juste le plaisir de servir une boisson à quelqu'un que vous aimez.",
+      "q3": "Que puis-je mettre au menu ?",
+      "a3": "Tout ce que vous voulez ! Café, thé, en-cas, tartines, eau… si vous pouvez le préparer dans votre cuisine, vous pouvez l'ajouter à votre menu."
+    },
+    "openSource": {
+      "title": "Fièrement open source",
+      "text": "Je crois en la transparence et en la communauté. My Tiny Café est open source : vous pouvez voir exactement comment il est construit, proposer des fonctionnalités ou l'héberger vous-même.",
+      "button": "Voir sur GitHub"
+    },
+    "footer": {
+      "title": "Prêt à ouvrir boutique ?",
+      "subtitle": "Rejoignez dès aujourd'hui la communauté des baristas à domicile.",
+      "cta": "Créer mon café maintenant",
+      "madeWith": "Fait avec ❤️ en France pour Zola et Magali.",
+      "copyright": "© 2024 My Tiny Café",
+      "aboutMakerTitle": "À propos du créateur",
+      "aboutMakerText": "Je m'appelle Alix, et j'ai créé ce projet pour rendre ma femme et ma fille heureuses. J'espère qu'il apportera aussi un peu de joie chez vous. Je suis développeur frontend freelance (de préférence en Vue.js / Nuxt.js), avec une formation en recherche sur l'interaction humain-machine. {link}.",
+      "aboutMakerLink": "Découvrez mon travail",
+      "guest": "Invité ?",
+      "findCafe": "Trouver un café"
+    }
+  },
+  "auth": {
+    "fields": {
+      "emailLabel": "E-mail",
+      "emailPlaceholder": "vous{'@'}exemple.com",
+      "emailFloating": "E-mail",
+      "passwordLabel": "Mot de passe",
+      "passwordFloating": "Mot de passe",
+      "nameLabel": "Nom",
+      "namePlaceholder": "Votre nom",
+      "nameFloating": "Votre nom",
+      "cafeIdLabel": "ID du café",
+      "cafeIdPlaceholder": "ID du café",
+      "cafeIdFloating": "L'ID de votre café"
+    },
+    "validation": {
+      "invalidEmail": "Adresse e-mail invalide",
+      "passwordMin": "Le mot de passe doit contenir au moins 8 caractères",
+      "nameMin": "Le nom doit contenir au moins 2 caractères",
+      "cafeIdMin": "L'ID du café doit contenir au moins 3 caractères"
+    },
+    "login": {
+      "title": "Connexion",
+      "submit": "Se connecter",
+      "noAccount": "Vous n'avez pas de compte ?",
+      "signupLink": "Inscrivez-vous",
+      "successTitle": "Connexion réussie !",
+      "successDesc": "Redirection…",
+      "failTitle": "Échec de la connexion",
+      "errorUnexpected": "Une erreur inattendue s'est produite. Veuillez réessayer."
+    },
+    "signup": {
+      "title": "Créer un compte",
+      "submit": "S'inscrire",
+      "haveAccount": "Vous avez déjà un compte ?",
+      "loginLink": "Se connecter",
+      "accountCreatedTitle": "Compte créé !",
+      "accountCreatedDesc": "Connectez-vous pour continuer.",
+      "invalidCafeIdTitle": "ID du café invalide",
+      "invalidCafeIdDesc": "L'ID du café ne peut pas être « undefined ». Veuillez choisir un autre ID de café.",
+      "cafeIdExistsTitle": "Cet ID de café existe déjà",
+      "cafeIdExistsDesc": "Veuillez choisir un autre ID de café.",
+      "failTitle": "Échec de l'inscription",
+      "failDesc": "Une erreur inattendue s'est produite."
+    }
+  },
+  "setup": {
+    "title": "Finaliser la configuration du café",
+    "intro": "Il semble qu'un problème soit survenu lors de la configuration de votre café. Veuillez renseigner les informations de votre café pour continuer.",
+    "cafeNameLabel": "Nom du café",
+    "cafeNamePlaceholder": "Mon super café",
+    "cafeNameFloating": "Nom du café",
+    "noSpecialChars": "Le nom de votre café ne peut pas contenir de caractères spéciaux ni d'espaces.",
+    "cafeIdLabel": "ID du café",
+    "cafeIdPlaceholder": "id-du-cafe",
+    "cafeIdFloating": "L'ID de votre café",
+    "submit": "Finaliser la configuration",
+    "cafeFoundTitle": "Café trouvé",
+    "cafeFoundDesc": "Redirection vers votre café…",
+    "authErrorTitle": "Erreur d'authentification",
+    "authErrorDesc": "Vous devez être connecté pour finaliser la configuration.",
+    "cafeIdExistsTitle": "Cet ID de café existe déjà",
+    "cafeIdExistsDesc": "Veuillez choisir un autre ID de café.",
+    "invalidCafeIdTitle": "ID du café invalide",
+    "invalidCafeIdDesc": "L'ID du café ne peut pas être « undefined ». Veuillez choisir un autre ID de café.",
+    "completeTitle": "Configuration terminée !",
+    "completeDesc": "Votre café est prêt.",
+    "failTitle": "Échec de la configuration",
+    "failDesc": "Une erreur inattendue s'est produite.",
+    "validation": {
+      "nameMin": "Le nom doit contenir au moins 2 caractères",
+      "cafeIdMin": "L'ID du café doit contenir au moins 3 caractères"
+    }
+  },
+  "menu": {
+    "beBarista": "Devenir le barista",
+    "heading": "Menu",
+    "pastOrders": "Commandes passées",
+    "unknownItem": "Article inconnu",
+    "yourName": "Votre nom",
+    "order": "Commander",
+    "anonymous": "Anonyme",
+    "status": {
+      "ordered": "Votre commande est en préparation",
+      "completed": "Votre commande est prête !",
+      "canceled": "Votre commande a été annulée",
+      "unknown": "Statut inconnu"
+    },
+    "toast": {
+      "orderSentTitle": "Commande envoyée",
+      "orderSentDesc": "Votre commande a bien été envoyée.",
+      "errorTitle": "Erreur",
+      "orderFailDesc": "Impossible d'envoyer votre commande. Veuillez réessayer.",
+      "orderCanceledTitle": "Commande annulée",
+      "orderCanceledDesc": "Votre commande a bien été annulée.",
+      "cancelFailDesc": "Impossible d'annuler votre commande. Veuillez réessayer."
+    },
+    "headDescription": "Commandez vos articles préférés chez {cafeName}"
+  },
+  "baristaOrders": {
+    "title": "Commande",
+    "enableNotifications": "Recevoir une notification à chaque nouvelle commande",
+    "emptyTitle": "Aucune commande pour le moment",
+    "emptyText": "Partagez la page de votre café pour commencer à recevoir des commandes !",
+    "shareCafe": "Partager mon café",
+    "pastOrders": "Commandes passées",
+    "cancel": "Annuler",
+    "complete": "Terminer",
+    "unknownItem": "Article inconnu",
+    "statusLabel": {
+      "ordered": "Commandé",
+      "completed": "Terminé",
+      "canceled": "Annulé"
+    }
+  },
+  "baristaMenu": {
+    "manageMenuFor": "Gérer le menu de {cafeName}",
+    "cafeId": "ID du café : {id}",
+    "addNewItem": "Ajouter un article",
+    "noItemsTitle": "Aucun article pour le moment",
+    "noItemsText": "Commencez par ajouter un article au menu.",
+    "options": "Options :",
+    "yesNo": "Oui / Non",
+    "noOptions": "Aucune option spécifique définie.",
+    "edit": "Modifier",
+    "delete": "Supprimer",
+    "editItemTitle": "Modifier {name}",
+    "addItemTitle": "Ajouter un article",
+    "itemNamePlaceholder": "ex. : Espresso, croissant",
+    "itemNameFloating": "Nom de l'article",
+    "pricePlaceholder": "ex. : 3,50",
+    "priceFloating": "Prix",
+    "imageLabel": "Image",
+    "noImage": "Aucune image",
+    "descriptionPlaceholder": "Description de l'article…",
+    "descriptionFloating": "Description",
+    "optionNamePlaceholder": "ex. : Taille, lait, déca",
+    "optionNameFloating": "Nom de l'option",
+    "multipleValues": "Valeurs multiples / Option simple",
+    "valuesFor": "Valeurs pour {name} :",
+    "thisOption": "cette option",
+    "valuePlaceholder": "ex. : Petit, grand, lait d'avoine",
+    "valueFloating": "Valeur",
+    "addValue": "Ajouter une valeur",
+    "addNewOptionType": "Ajouter un type d'option",
+    "removeOption": "Supprimer l'option",
+    "removeValue": "Supprimer la valeur",
+    "cancel": "Annuler",
+    "saveChanges": "Enregistrer les modifications",
+    "addItem": "Ajouter l'article",
+    "confirmDelete": "Voulez-vous vraiment supprimer cet article ? Cette action est irréversible.",
+    "images": {
+      "bobba": "Bubble tea",
+      "cafe": "Café",
+      "cookie": "Cookie",
+      "emporter": "À emporter",
+      "gaiwan": "Gaiwan",
+      "jus": "Jus",
+      "latte": "Latte",
+      "muffin": "Muffin",
+      "mug": "Mug",
+      "tartine": "Tartine",
+      "the": "Thé",
+      "yaourt": "Yaourt"
+    },
+    "toast": {
+      "errorLoadingCafeTitle": "Erreur de chargement du café",
+      "errorLoadingCafeDesc": "Le café demandé est introuvable ou n'a pas pu être chargé.",
+      "errorLoadingMenuTitle": "Erreur de chargement du menu",
+      "errorLoadingMenuDesc": "Impossible de charger les articles du menu.",
+      "errorTitle": "Erreur",
+      "cafeIdMissing": "L'ID du café est manquant.",
+      "itemDeletedTitle": "Article supprimé",
+      "itemDeletedDesc": "L'article a bien été supprimé.",
+      "deletionFailedTitle": "Échec de la suppression",
+      "deletionFailedDesc": "Impossible de supprimer l'article.",
+      "validationErrorTitle": "Erreur de validation",
+      "itemNameRequired": "Le nom de l'article est requis.",
+      "itemUpdatedTitle": "Article mis à jour",
+      "itemUpdatedDesc": "Modifications enregistrées avec succès.",
+      "itemAddedTitle": "Article ajouté",
+      "itemAddedDesc": "Nouvel article ajouté au menu.",
+      "saveFailedTitle": "Échec de l'enregistrement",
+      "saveFailedDesc": "Impossible d'enregistrer l'article."
+    }
+  },
+  "cafeSettings": {
+    "share": {
+      "title": "Partagez votre page",
+      "subtitle": "Partagez cette page à l'aide de l'URL ou du QR code ci-dessous.",
+      "pageUrlLabel": "URL de la page",
+      "pageUrlHelp": "C'est le lien direct vers votre page.",
+      "generatingUrl": "Génération de l'URL…"
+    },
+    "qr": {
+      "title": "QR code",
+      "subtitle": "Scannez ce QR code avec un appareil mobile pour ouvrir la page.",
+      "downloadPng": "Télécharger en PNG",
+      "unavailable": "URL de la page indisponible, le QR code ne peut pas être généré."
+    },
+    "updateName": {
+      "title": "Modifier le nom du café",
+      "subtitle": "Modifiez le nom de votre café.",
+      "label": "Nom du café",
+      "help": "Saisissez le nouveau nom de votre café.",
+      "placeholder": "Saisir le nouveau nom du café",
+      "update": "Mettre à jour",
+      "updating": "Mise à jour…"
+    },
+    "customImages": {
+      "title": "Images personnalisées",
+      "subtitle": "Importez vos propres images pour les utiliser dans vos articles du menu.",
+      "upload": "Importer une image",
+      "empty": "Aucune image personnalisée pour le moment. Importez-en une pour commencer."
+    },
+    "about": {
+      "title": "À propos & soutien",
+      "openSourceTitle": "Open source",
+      "openSourceText": "Ce projet est en partie open source. La configuration du serveur Appwrite disponible sur GitHub est probablement obsolète, n'hésitez pas à me contacter si vous avez besoin de quoi que ce soit.",
+      "viewOnGithub": "Voir sur GitHub",
+      "contactTitle": "Contacter le créateur",
+      "contactText": "Créé par Alix. Contactez-moi si vous avez besoin de quoi que ce soit.",
+      "hireText": "Et si vous m'engagiez pour votre prochain projet ?",
+      "supportTitle": "Soutenir My Tiny Café",
+      "supportText": "My Tiny Café est disponible gratuitement, mais si vous aimez l'utiliser, pensez à participer à ses frais d'hébergement.",
+      "supportButton": "Soutenir sur Buy Me a Coffee"
+    },
+    "delete": {
+      "title": "Supprimer le compte",
+      "subtitle": "Supprimez définitivement votre café, son menu, toutes les commandes, vos images personnalisées et votre compte. Cette action est irréversible.",
+      "button": "Supprimer mon compte",
+      "modalTitle": "Supprimer définitivement votre compte ?",
+      "modalIntro": "Cela supprimera définitivement :",
+      "modalListCafe": "votre café {id}",
+      "modalListMenu": "ses articles du menu et toutes les commandes passées",
+      "modalListImages": "vos images personnalisées",
+      "modalListAccount": "votre compte (vous ne pourrez plus vous reconnecter)",
+      "confirmLabel": "Saisissez « {cafeId} » pour confirmer",
+      "deletePermanently": "Supprimer définitivement"
+    },
+    "session": {
+      "title": "Session",
+      "subtitle": "Déconnectez-vous de cet appareil. Vous pourrez vous reconnecter à tout moment.",
+      "logout": "Se déconnecter"
+    },
+    "toast": {
+      "imageUploadedTitle": "Image importée",
+      "imageUploadedDesc": "« {name} » a bien été importée.",
+      "uploadFailedTitle": "Échec de l'import",
+      "uploadFailedDesc": "Impossible d'importer l'image.",
+      "confirmDeleteImage": "Supprimer cette image ? Les articles qui l'utilisent afficheront une image cassée.",
+      "imageDeletedTitle": "Image supprimée",
+      "imageDeletedDesc": "L'image a bien été supprimée.",
+      "deleteFailedTitle": "Échec de la suppression",
+      "deleteFailedDesc": "Impossible de supprimer l'image.",
+      "errorTitle": "Erreur",
+      "cafeIdUnavailable": "L'ID du café n'est pas disponible. Impossible de mettre à jour le nom.",
+      "validationErrorTitle": "Erreur de validation",
+      "cafeNameEmpty": "Le nom du café ne peut pas être vide.",
+      "successTitle": "Succès !",
+      "cafeNameUpdated": "Nom du café mis à jour : « {name} ».",
+      "updateFailedTitle": "Échec de la mise à jour",
+      "updateNameFailedDesc": "Impossible de mettre à jour le nom du café. Veuillez réessayer.",
+      "missingCafeIdTitle": "ID du café manquant",
+      "missingCafeIdDesc": "L'identifiant unique du café est absent de l'URL.",
+      "urlNotAvailableTitle": "URL indisponible",
+      "urlNotAvailableDesc": "L'URL de la page n'est pas prête à être copiée.",
+      "clipboardDeniedTitle": "Accès au presse-papiers refusé",
+      "clipboardDeniedDesc": "Les paramètres de votre navigateur empêchent l'accès au presse-papiers, ou celui-ci n'est pas pris en charge.",
+      "urlCopiedTitle": "URL copiée !",
+      "urlCopiedDesc": "L'URL de la page a été copiée dans votre presse-papiers.",
+      "copyUnconfirmedTitle": "Copie non confirmée",
+      "copyUnconfirmedDesc": "Tentative de copie effectuée. Veuillez vérifier votre presse-papiers.",
+      "copyFailedTitle": "Échec de la copie",
+      "copyFailedDesc": "Une erreur s'est produite lors de la copie de l'URL. Veuillez la copier manuellement.",
+      "downloadFailedTitle": "Échec du téléchargement",
+      "qrNotReady": "Le QR code n'est pas encore prêt. Veuillez réessayer.",
+      "qrDownloadedTitle": "QR code téléchargé",
+      "qrDownloadedDesc": "Le PNG du QR code a bien été enregistré.",
+      "qrGenerateFailed": "Impossible de générer le fichier PNG. Veuillez réessayer.",
+      "loggedOutTitle": "Déconnecté",
+      "loggedOutDesc": "Vous avez été déconnecté",
+      "accountDeletedTitle": "Compte supprimé",
+      "accountDeletedDesc": "Votre compte et votre café ont été définitivement supprimés.",
+      "deletionFailedTitle": "Échec de la suppression",
+      "deletionFailedDesc": "Impossible de supprimer votre compte. Veuillez réessayer."
+    }
+  },
+  "invalidCafe": {
+    "title": "Ce café est fermé.",
+    "text": "Nous n'avons trouvé aucun café à cette adresse. Peut-être que le lien est erroné — ou peut-être qu'il est temps pour {you} d'ouvrir le vôtre ?",
+    "textHighlight": "vous",
+    "openOwn": "Ouvrir mon propre café",
+    "backHome": "Retour à l'accueil",
+    "noCreditCard": "Pas de carte bancaire. Pas de pub. Juste de l'amour.",
+    "headTitle": "Café introuvable — My Tiny Café"
+  },
+  "pwa": {
+    "finding": "Recherche de votre coin café…",
+    "redirecting": "Redirection vers votre dernier café visité."
+  },
+  "demo": {
+    "cafeName": "Chez Zola",
+    "promptTitle": "Envie de votre propre café à la maison ?",
+    "promptText": "Si vous rêvez d'ouvrir votre petit café pour vos proches et votre famille, inscrivez-vous — c'est entièrement gratuit, sans pub, et ça prend environ une minute.",
+    "openCafe": "Ouvrir mon petit café",
+    "keepBrowsing": "Continuer à explorer",
+    "items": {
+      "latte": {
+        "name": "Latte",
+        "description": "Espresso velouté coiffé de lait moussé.",
+        "price": "1 câlin 🤗"
+      },
+      "espresso": {
+        "name": "Espresso",
+        "description": "Court, noir, intense. Le classique."
+      },
+      "matcha": {
+        "name": "Matcha",
+        "description": "Thé vert de qualité cérémonie fouetté."
+      },
+      "tea": {
+        "name": "Thé",
+        "description": "En feuilles, infusé à la demande."
+      },
+      "juice": {
+        "name": "Jus frais",
+        "description": "Pressé ce matin."
+      },
+      "bubble": {
+        "name": "Bubble tea",
+        "description": "Tapioca moelleux, votre parfum préféré."
+      },
+      "muffin": {
+        "name": "Muffin",
+        "description": "Cuit ce matin."
+      },
+      "cookie": {
+        "name": "Cookie",
+        "description": "Tiède et moelleux."
+      },
+      "tartine": {
+        "name": "Tartine",
+        "description": "Pain au levain, grillé, avec garnitures."
+      },
+      "yogurt": {
+        "name": "Yaourt",
+        "description": "Yaourt grec, fruits frais, granola.",
+        "price": "Gratuit !"
+      }
+    }
+  }
+}

--- a/i18n/locales/it.json
+++ b/i18n/locales/it.json
@@ -1,0 +1,475 @@
+{
+  "common": {
+    "cancel": "Annulla",
+    "save": "Salva",
+    "delete": "Elimina",
+    "edit": "Modifica",
+    "close": "Chiudi",
+    "copy": "Copia",
+    "copied": "Copiato!",
+    "loading": "Caricamento..."
+  },
+  "nav": {
+    "orders": "Ordini",
+    "menu": "Menu",
+    "cafe": "Caffetteria"
+  },
+  "languageSwitcher": {
+    "label": "Lingua"
+  },
+  "app": {
+    "name": "My Tiny Café",
+    "description": "Ordina dalla tua caffetteria preferita"
+  },
+  "landing": {
+    "nav": {
+      "login": "Accedi",
+      "openCafe": "Apri il mio My Tiny Café"
+    },
+    "hero": {
+      "title": "Trasforma casa tua nel {highlight} del quartiere.",
+      "titleHighlight": "Miglior Coffee Shop",
+      "subtitle": "Il menu digitale per i barista di casa. Crea la tua lista di bevande, condividi il QR code con amici e parenti e ricevi gli ordini direttamente sul telefono.",
+      "subtitleEmphasis": "100% Gratis. 100% Accogliente.",
+      "ctaPrimary": "Apri il mio My Tiny Café",
+      "ctaDemo": "Guarda una caffetteria demo ↗",
+      "noCreditCard": "Nessuna carta di credito richiesta. Niente pubblicità. Solo amore."
+    },
+    "mockup": {
+      "notifTitle": "Nuovo ordine da Magali",
+      "notifOrder": "Latte (Latte d'avena, Senza zucchero)",
+      "now": "adesso",
+      "menu": "Menu",
+      "latte": "Latte",
+      "lattePrice": "1 abbraccio 🤗",
+      "matcha": "Matcha",
+      "tea": "Tè",
+      "teaPrice": "Una storia 📖",
+      "cookie": "Biscotto",
+      "cookiePrice": "Gratis!"
+    },
+    "valueProp": {
+      "eyebrow": "L'ospitalità, migliorata",
+      "heading": "Perché urlare dalla cucina?",
+      "problemTitle": "Il problema",
+      "problemText": "Urlare dalla cucina «Chi vuole il tè?» e, quando l'acqua bolle, aver già dimenticato chi voleva lo zucchero e chi il latte di mandorla.",
+      "solutionTitle": "La soluzione",
+      "solutionText": "My Tiny Café porta nel tuo salotto la magia di una boutique del caffè. Rendi il momento speciale."
+    },
+    "howItWorks": {
+      "title": "Come funziona (3 semplici passi)",
+      "step1Title": "1. Crea il tuo menu",
+      "step1Text": "Dai un nome alla tua caffetteria. Aggiungi le tue specialità—Latte, Tisana o Bruschetta. Personalizza le opzioni per latte e zucchero.",
+      "step2Title": "2. Condividi il link",
+      "step2Text": "Stampa il QR code per il frigorifero o invia il link via messaggio. Gli ospiti sfogliano il menu e personalizzano la loro bevanda esattamente come la desiderano.",
+      "step3Title": "3. Ricevi la notifica e servi",
+      "step3Text": "Ding! Ricevi una notifica all'istante. Nessuno scambio di denaro—solo una tazza perfetta servita con un sorriso."
+    },
+    "features": {
+      "title": "Funzionalità",
+      "feature1Title": "Menu completamente personalizzabile",
+      "feature1Text": "Dalla «Tisana per l'allattamento» al «Matcha freddo», decidi tu cosa servire.",
+      "feature2Title": "Notifiche push istantanee",
+      "feature2Text": "Non perdere mai un ordine. Saprai nell'istante esatto in cui il tuo «cliente» invia la richiesta.",
+      "feature3Title": "Nessuna app da scaricare",
+      "feature3Text": "Gli ospiti scansionano (o cliccano) e ordinano. Nessuna installazione necessaria.",
+      "feature4Title": "Completamente gratis",
+      "feature4Text": "Nessun sistema di pagamento. L'unica moneta qui è la gratitudine."
+    },
+    "stories": {
+      "title": "Storie vere",
+      "quote1": "Papà, posso usare la tua app per ordinare un tè?",
+      "quote1Name": "Zola, 5 anni",
+      "quote1Role": "Capo Assaggiatrice",
+      "quote2": "È così comodo ordinare un caffè per quando torno a casa. E il barista è anche super carino!",
+      "quote2Name": "Magali",
+      "quote2Role": "Moglie e cliente affezionata"
+    },
+    "audience": {
+      "title": "Per chi è My Tiny Café?",
+      "card1Title": "La coppia in smart working",
+      "card1Text": "Invia in silenzio un ordine per una carica di caffeina senza interrompere la riunione su Zoom.",
+      "card2Title": "Il padrone di casa perfetto",
+      "card2Text": "Stupisci i tuoi ospiti lasciando che ordinino il digestivo di fine pasto da un menu digitale.",
+      "card3Title": "Il genitore giocherellone",
+      "card3Text": "I bambini adorano giocare al «ristorante». Prepara il menu per loro e lascia che prendano la tua ordinazione."
+    },
+    "faq": {
+      "title": "Domande frequenti",
+      "q1": "È davvero gratis?",
+      "a1": "Sì! Al momento My Tiny Café è completamente gratuito.",
+      "q2": "Posso far pagare le bevande?",
+      "a2": "No. Questa app è pensata per amici e parenti. Non c'è alcun sistema di pagamento—solo la gioia di servire una bevanda a una persona a cui tieni.",
+      "q3": "Cosa posso mettere nel menu?",
+      "a3": "Qualsiasi cosa! Caffè, tè, snack, bruschette, acqua... se riesci a prepararlo in cucina, puoi metterlo nel tuo menu."
+    },
+    "openSource": {
+      "title": "Orgogliosamente open source",
+      "text": "Credo nella trasparenza e nella comunità. My Tiny Café è open source, così puoi vedere esattamente com'è costruito, contribuire con nuove funzionalità o ospitarlo tu stesso.",
+      "button": "Guarda su GitHub"
+    },
+    "footer": {
+      "title": "Pronto ad aprire bottega?",
+      "subtitle": "Unisciti oggi alla comunità dei barista di casa.",
+      "cta": "Crea ora la tua caffetteria",
+      "madeWith": "Fatto con ❤️ in Francia per Zola e Magali.",
+      "copyright": "© 2024 My Tiny Café",
+      "aboutMakerTitle": "Chi l'ha creato",
+      "aboutMakerText": "Sono Alix, ho creato questa app per rendere felici mia moglie e mia figlia. Spero che porti un po' di gioia anche a casa tua. Sono uno sviluppatore frontend freelance (preferibilmente in Vue.js / Nuxt.js) con un background nella ricerca sull'interazione uomo-macchina. {link}.",
+      "aboutMakerLink": "Dai un'occhiata ai miei lavori",
+      "guest": "Ospite?",
+      "findCafe": "Trova una caffetteria"
+    }
+  },
+  "auth": {
+    "fields": {
+      "emailLabel": "Email",
+      "emailPlaceholder": "tu{'@'}esempio.com",
+      "emailFloating": "Email",
+      "passwordLabel": "Password",
+      "passwordFloating": "Password",
+      "nameLabel": "Nome",
+      "namePlaceholder": "Il tuo nome",
+      "nameFloating": "Il tuo nome",
+      "cafeIdLabel": "ID caffetteria",
+      "cafeIdPlaceholder": "ID caffetteria",
+      "cafeIdFloating": "L'ID della tua caffetteria"
+    },
+    "validation": {
+      "invalidEmail": "Indirizzo email non valido",
+      "passwordMin": "La password deve contenere almeno 8 caratteri",
+      "nameMin": "Il nome deve contenere almeno 2 caratteri",
+      "cafeIdMin": "L'ID della caffetteria deve contenere almeno 3 caratteri"
+    },
+    "login": {
+      "title": "Accedi",
+      "submit": "Accedi",
+      "noAccount": "Non hai un account?",
+      "signupLink": "Registrati",
+      "successTitle": "Accesso riuscito!",
+      "successDesc": "Reindirizzamento in corso...",
+      "failTitle": "Accesso non riuscito",
+      "errorUnexpected": "Si è verificato un errore imprevisto. Riprova."
+    },
+    "signup": {
+      "title": "Crea un account",
+      "submit": "Registrati",
+      "haveAccount": "Hai già un account?",
+      "loginLink": "Accedi",
+      "accountCreatedTitle": "Account creato!",
+      "accountCreatedDesc": "Accedi per continuare.",
+      "invalidCafeIdTitle": "ID caffetteria non valido",
+      "invalidCafeIdDesc": "L'ID della caffetteria non può essere «undefined». Scegli un ID diverso.",
+      "cafeIdExistsTitle": "ID caffetteria già esistente",
+      "cafeIdExistsDesc": "Scegli un ID caffetteria diverso.",
+      "failTitle": "Registrazione non riuscita",
+      "failDesc": "Si è verificato un errore imprevisto."
+    }
+  },
+  "setup": {
+    "title": "Completa la configurazione della caffetteria",
+    "intro": "Sembra che qualcosa sia andato storto durante la configurazione della tua caffetteria. Inserisci i dettagli della caffetteria per continuare.",
+    "cafeNameLabel": "Nome della caffetteria",
+    "cafeNamePlaceholder": "La mia fantastica caffetteria",
+    "cafeNameFloating": "Nome della caffetteria",
+    "noSpecialChars": "Il nome della tua caffetteria non può contenere caratteri speciali o spazi.",
+    "cafeIdLabel": "ID caffetteria",
+    "cafeIdPlaceholder": "id-caffetteria",
+    "cafeIdFloating": "L'ID della tua caffetteria",
+    "submit": "Completa la configurazione",
+    "cafeFoundTitle": "Caffetteria trovata",
+    "cafeFoundDesc": "Reindirizzamento alla tua caffetteria...",
+    "authErrorTitle": "Errore di autenticazione",
+    "authErrorDesc": "Devi aver effettuato l'accesso per completare la configurazione.",
+    "cafeIdExistsTitle": "ID caffetteria già esistente",
+    "cafeIdExistsDesc": "Scegli un ID caffetteria diverso.",
+    "invalidCafeIdTitle": "ID caffetteria non valido",
+    "invalidCafeIdDesc": "L'ID della caffetteria non può essere «undefined». Scegli un ID diverso.",
+    "completeTitle": "Configurazione completata!",
+    "completeDesc": "La tua caffetteria è pronta.",
+    "failTitle": "Configurazione non riuscita",
+    "failDesc": "Si è verificato un errore imprevisto.",
+    "validation": {
+      "nameMin": "Il nome deve contenere almeno 2 caratteri",
+      "cafeIdMin": "L'ID della caffetteria deve contenere almeno 3 caratteri"
+    }
+  },
+  "menu": {
+    "beBarista": "Diventa il barista",
+    "heading": "Menu",
+    "pastOrders": "Ordini passati",
+    "unknownItem": "Articolo sconosciuto",
+    "yourName": "Il tuo nome",
+    "order": "Ordina",
+    "anonymous": "Anonimo",
+    "status": {
+      "ordered": "Il tuo ordine è in preparazione",
+      "completed": "Il tuo ordine è pronto!",
+      "canceled": "Il tuo ordine è stato annullato",
+      "unknown": "Stato sconosciuto"
+    },
+    "toast": {
+      "orderSentTitle": "Ordine inviato",
+      "orderSentDesc": "Il tuo ordine è stato inviato con successo.",
+      "errorTitle": "Errore",
+      "orderFailDesc": "Invio dell'ordine non riuscito. Riprova.",
+      "orderCanceledTitle": "Ordine annullato",
+      "orderCanceledDesc": "Il tuo ordine è stato annullato con successo.",
+      "cancelFailDesc": "Annullamento dell'ordine non riuscito. Riprova."
+    },
+    "headDescription": "Ordina i tuoi articoli preferiti da {cafeName}"
+  },
+  "baristaOrders": {
+    "title": "Ordine",
+    "enableNotifications": "Ricevi una notifica quando viene inviato un nuovo ordine",
+    "emptyTitle": "Ancora nessun ordine",
+    "emptyText": "Condividi la pagina della tua caffetteria per iniziare a ricevere ordini!",
+    "shareCafe": "Condividi la mia caffetteria",
+    "pastOrders": "Ordini passati",
+    "cancel": "Annulla",
+    "complete": "Completa",
+    "unknownItem": "Articolo sconosciuto",
+    "statusLabel": {
+      "ordered": "Ordinato",
+      "completed": "Completato",
+      "canceled": "Annullato"
+    }
+  },
+  "baristaMenu": {
+    "manageMenuFor": "Gestisci il menu di {cafeName}",
+    "cafeId": "ID caffetteria: {id}",
+    "addNewItem": "Aggiungi nuovo articolo",
+    "noItemsTitle": "Ancora nessun articolo",
+    "noItemsText": "Inizia aggiungendo un nuovo articolo al menu.",
+    "options": "Opzioni:",
+    "yesNo": "Sì / No",
+    "noOptions": "Nessuna opzione specifica definita.",
+    "edit": "Modifica",
+    "delete": "Elimina",
+    "editItemTitle": "Modifica {name}",
+    "addItemTitle": "Aggiungi nuovo articolo",
+    "itemNamePlaceholder": "es. Espresso, Croissant",
+    "itemNameFloating": "Nome dell'articolo",
+    "pricePlaceholder": "es. 3,50",
+    "priceFloating": "Prezzo",
+    "imageLabel": "Immagine",
+    "noImage": "Nessuna immagine",
+    "descriptionPlaceholder": "Descrizione dell'articolo...",
+    "descriptionFloating": "Descrizione",
+    "optionNamePlaceholder": "es. Dimensione, Latte, Decaffeinato",
+    "optionNameFloating": "Nome dell'opzione",
+    "multipleValues": "Valori multipli / Opzione semplice",
+    "valuesFor": "Valori per {name}:",
+    "thisOption": "questa opzione",
+    "valuePlaceholder": "es. Piccolo, Grande, Latte d'avena",
+    "valueFloating": "Valore",
+    "addValue": "Aggiungi valore",
+    "addNewOptionType": "Aggiungi nuovo tipo di opzione",
+    "removeOption": "Rimuovi opzione",
+    "removeValue": "Rimuovi valore",
+    "cancel": "Annulla",
+    "saveChanges": "Salva modifiche",
+    "addItem": "Aggiungi articolo",
+    "confirmDelete": "Sei sicuro di voler eliminare questo articolo? Questa azione non può essere annullata.",
+    "images": {
+      "bobba": "Bubble tea",
+      "cafe": "Caffè",
+      "cookie": "Biscotto",
+      "emporter": "Da asporto",
+      "gaiwan": "Gaiwan",
+      "jus": "Succo",
+      "latte": "Latte",
+      "muffin": "Muffin",
+      "mug": "Tazza",
+      "tartine": "Bruschetta",
+      "the": "Tè",
+      "yaourt": "Yogurt"
+    },
+    "toast": {
+      "errorLoadingCafeTitle": "Errore nel caricamento della caffetteria",
+      "errorLoadingCafeDesc": "La caffetteria richiesta non è stata trovata o non è stato possibile caricarla.",
+      "errorLoadingMenuTitle": "Errore nel caricamento del menu",
+      "errorLoadingMenuDesc": "Impossibile caricare gli articoli del menu.",
+      "errorTitle": "Errore",
+      "cafeIdMissing": "L'ID della caffetteria è mancante.",
+      "itemDeletedTitle": "Articolo eliminato",
+      "itemDeletedDesc": "L'articolo è stato eliminato con successo.",
+      "deletionFailedTitle": "Eliminazione non riuscita",
+      "deletionFailedDesc": "Impossibile eliminare l'articolo.",
+      "validationErrorTitle": "Errore di convalida",
+      "itemNameRequired": "Il nome dell'articolo è obbligatorio.",
+      "itemUpdatedTitle": "Articolo aggiornato",
+      "itemUpdatedDesc": "Modifiche salvate con successo.",
+      "itemAddedTitle": "Articolo aggiunto",
+      "itemAddedDesc": "Nuovo articolo aggiunto al menu.",
+      "saveFailedTitle": "Salvataggio non riuscito",
+      "saveFailedDesc": "Impossibile salvare l'articolo."
+    }
+  },
+  "cafeSettings": {
+    "share": {
+      "title": "Condividi la tua pagina",
+      "subtitle": "Condividi questa pagina usando l'URL o il QR code qui sotto.",
+      "pageUrlLabel": "URL della pagina",
+      "pageUrlHelp": "Questo è il link diretto alla tua pagina.",
+      "generatingUrl": "Generazione dell'URL..."
+    },
+    "qr": {
+      "title": "QR code",
+      "subtitle": "Scansiona questo QR code con un dispositivo mobile per aprire la pagina.",
+      "downloadPng": "Scarica PNG",
+      "unavailable": "URL della pagina non disponibile, impossibile generare il QR code."
+    },
+    "updateName": {
+      "title": "Aggiorna il nome della caffetteria",
+      "subtitle": "Modifica il nome della tua caffetteria.",
+      "label": "Nome della caffetteria",
+      "help": "Inserisci il nuovo nome per la tua caffetteria.",
+      "placeholder": "Inserisci il nuovo nome della caffetteria",
+      "update": "Aggiorna",
+      "updating": "Aggiornamento..."
+    },
+    "customImages": {
+      "title": "Immagini personalizzate",
+      "subtitle": "Carica le tue immagini da usare negli articoli del menu.",
+      "upload": "Carica immagine",
+      "empty": "Ancora nessuna immagine personalizzata. Caricane una per iniziare."
+    },
+    "about": {
+      "title": "Informazioni e supporto",
+      "openSourceTitle": "Open source",
+      "openSourceText": "Questo progetto è in parte open source. La configurazione del server Appwrite disponibile su GitHub è probabilmente obsoleta, contattami se ti serve qualcosa.",
+      "viewOnGithub": "Guarda su GitHub",
+      "contactTitle": "Contatta il creatore",
+      "contactText": "Creato da Alix. Contattami se ti serve qualcosa.",
+      "hireText": "Che ne dici di ingaggiarmi per il tuo prossimo progetto?",
+      "supportTitle": "Sostieni My Tiny Café",
+      "supportText": "My Tiny Café è disponibile gratuitamente, ma se ti piace usarlo, valuta di contribuire ai costi di hosting.",
+      "supportButton": "Sostieni su Buy Me a Coffee"
+    },
+    "delete": {
+      "title": "Elimina account",
+      "subtitle": "Elimina definitivamente la tua caffetteria, il suo menu, tutti gli ordini, le immagini personalizzate e il tuo account. Questa azione non può essere annullata.",
+      "button": "Elimina il mio account",
+      "modalTitle": "Eliminare definitivamente il tuo account?",
+      "modalIntro": "Questo eliminerà definitivamente:",
+      "modalListCafe": "la tua caffetteria {id}",
+      "modalListMenu": "i suoi articoli del menu e tutti gli ordini passati",
+      "modalListImages": "le tue immagini personalizzate",
+      "modalListAccount": "il tuo account (non potrai più accedere)",
+      "confirmLabel": "Digita «{cafeId}» per confermare",
+      "deletePermanently": "Elimina definitivamente"
+    },
+    "session": {
+      "title": "Sessione",
+      "subtitle": "Esci da questo dispositivo. Puoi accedere di nuovo quando vuoi.",
+      "logout": "Esci"
+    },
+    "toast": {
+      "imageUploadedTitle": "Immagine caricata",
+      "imageUploadedDesc": "«{name}» è stata caricata.",
+      "uploadFailedTitle": "Caricamento non riuscito",
+      "uploadFailedDesc": "Impossibile caricare l'immagine.",
+      "confirmDeleteImage": "Eliminare questa immagine? Gli articoli che la usano mostreranno un'immagine non disponibile.",
+      "imageDeletedTitle": "Immagine eliminata",
+      "imageDeletedDesc": "L'immagine è stata eliminata.",
+      "deleteFailedTitle": "Eliminazione non riuscita",
+      "deleteFailedDesc": "Impossibile eliminare l'immagine.",
+      "errorTitle": "Errore",
+      "cafeIdUnavailable": "L'ID della caffetteria non è disponibile. Impossibile aggiornare il nome.",
+      "validationErrorTitle": "Errore di convalida",
+      "cafeNameEmpty": "Il nome della caffetteria non può essere vuoto.",
+      "successTitle": "Fatto!",
+      "cafeNameUpdated": "Nome della caffetteria aggiornato in «{name}».",
+      "updateFailedTitle": "Aggiornamento non riuscito",
+      "updateNameFailedDesc": "Impossibile aggiornare il nome della caffetteria. Riprova.",
+      "missingCafeIdTitle": "ID caffetteria mancante",
+      "missingCafeIdDesc": "L'identificatore univoco della caffetteria è mancante nell'URL.",
+      "urlNotAvailableTitle": "URL non disponibile",
+      "urlNotAvailableDesc": "L'URL della pagina non è pronto per essere copiato.",
+      "clipboardDeniedTitle": "Accesso agli appunti negato",
+      "clipboardDeniedDesc": "Le impostazioni del tuo browser impediscono l'accesso agli appunti, oppure non è supportato.",
+      "urlCopiedTitle": "URL copiato!",
+      "urlCopiedDesc": "L'URL della pagina è stato copiato negli appunti.",
+      "copyUnconfirmedTitle": "Copia non confermata",
+      "copyUnconfirmedDesc": "Tentativo di copia eseguito. Verifica i tuoi appunti.",
+      "copyFailedTitle": "Copia non riuscita",
+      "copyFailedDesc": "Si è verificato un errore durante il tentativo di copia dell'URL. Copialo manualmente.",
+      "downloadFailedTitle": "Download non riuscito",
+      "qrNotReady": "Il QR code non è ancora pronto. Riprova.",
+      "qrDownloadedTitle": "QR code scaricato",
+      "qrDownloadedDesc": "Il PNG del QR code è stato salvato.",
+      "qrGenerateFailed": "Impossibile generare il file PNG. Riprova.",
+      "loggedOutTitle": "Disconnesso",
+      "loggedOutDesc": "Hai effettuato la disconnessione",
+      "accountDeletedTitle": "Account eliminato",
+      "accountDeletedDesc": "Il tuo account e la tua caffetteria sono stati eliminati definitivamente.",
+      "deletionFailedTitle": "Eliminazione non riuscita",
+      "deletionFailedDesc": "Impossibile eliminare il tuo account. Riprova."
+    }
+  },
+  "invalidCafe": {
+    "title": "Questa caffetteria è chiusa.",
+    "text": "Non abbiamo trovato nessuna caffetteria a questo indirizzo. Forse il link è sbagliato — o forse è arrivato il momento per {you} di aprire la tua?",
+    "textHighlight": "te",
+    "openOwn": "Apri la mia caffetteria",
+    "backHome": "Torna alla home",
+    "noCreditCard": "Nessuna carta di credito. Niente pubblicità. Solo amore.",
+    "headTitle": "Caffetteria non trovata — My Tiny Café"
+  },
+  "pwa": {
+    "finding": "Stiamo cercando il tuo posto...",
+    "redirecting": "Ti stiamo reindirizzando all'ultima caffetteria visitata."
+  },
+  "demo": {
+    "cafeName": "Chez Zola",
+    "promptTitle": "Vuoi la tua caffetteria di casa?",
+    "promptText": "Se ti piacerebbe aprire la tua piccola caffetteria per amici e parenti, registrati — è completamente gratis, senza pubblicità e ci vuole circa un minuto.",
+    "openCafe": "Apri la mia piccola caffetteria",
+    "keepBrowsing": "Continua a sfogliare",
+    "items": {
+      "latte": {
+        "name": "Latte",
+        "description": "Espresso vellutato sormontato da latte montato.",
+        "price": "1 abbraccio 🤗"
+      },
+      "espresso": {
+        "name": "Espresso",
+        "description": "Corto, scuro, intenso. Il classico."
+      },
+      "matcha": {
+        "name": "Matcha",
+        "description": "Tè verde di grado cerimoniale, montato a frusta."
+      },
+      "tea": {
+        "name": "Tè",
+        "description": "Foglie sfuse, in infusione al momento."
+      },
+      "juice": {
+        "name": "Succo fresco",
+        "description": "Spremuto stamattina."
+      },
+      "bubble": {
+        "name": "Bubble tea",
+        "description": "Perle di tapioca, il tuo gusto preferito."
+      },
+      "muffin": {
+        "name": "Muffin",
+        "description": "Sfornato stamattina."
+      },
+      "cookie": {
+        "name": "Biscotto",
+        "description": "Caldo e morbido."
+      },
+      "tartine": {
+        "name": "Bruschetta",
+        "description": "Pasta madre, tostata, con condimenti."
+      },
+      "yogurt": {
+        "name": "Yogurt",
+        "description": "Yogurt greco, frutta fresca, granola.",
+        "price": "Gratis!"
+      }
+    }
+  }
+}

--- a/i18n/locales/zh.json
+++ b/i18n/locales/zh.json
@@ -1,0 +1,475 @@
+{
+  "common": {
+    "cancel": "取消",
+    "save": "保存",
+    "delete": "删除",
+    "edit": "编辑",
+    "close": "关闭",
+    "copy": "复制",
+    "copied": "已复制！",
+    "loading": "加载中……"
+  },
+  "nav": {
+    "orders": "订单",
+    "menu": "菜单",
+    "cafe": "咖啡馆"
+  },
+  "languageSwitcher": {
+    "label": "语言"
+  },
+  "app": {
+    "name": "My Tiny Café",
+    "description": "点一杯你最爱的咖啡馆"
+  },
+  "landing": {
+    "nav": {
+      "login": "登录",
+      "openCafe": "开一家 My Tiny Café"
+    },
+    "hero": {
+      "title": "把你的家变成全城{highlight}。",
+      "titleHighlight": "最棒的咖啡馆",
+      "subtitle": "为居家咖啡师打造的电子菜单。列出你的饮品清单，把二维码分享给亲朋好友，订单直接送到你的手机上。",
+      "subtitleEmphasis": "100% 免费。100% 温馨。",
+      "ctaPrimary": "开一家 My Tiny Café",
+      "ctaDemo": "看看示例咖啡馆 ↗",
+      "noCreditCard": "无需信用卡，没有广告，只有满满的爱。"
+    },
+    "mockup": {
+      "notifTitle": "来自 Magali 的新订单",
+      "notifOrder": "拿铁（燕麦奶，无糖）",
+      "now": "刚刚",
+      "menu": "菜单",
+      "latte": "拿铁",
+      "lattePrice": "一个拥抱 🤗",
+      "matcha": "抹茶",
+      "tea": "茶",
+      "teaPrice": "一个故事 📖",
+      "cookie": "曲奇",
+      "cookiePrice": "免费！"
+    },
+    "valueProp": {
+      "eyebrow": "升级你的待客之道",
+      "heading": "何必从厨房里扯着嗓子喊？",
+      "problemTitle": "烦恼所在",
+      "problemText": "从厨房里喊一声「谁要喝茶？」，可水还没烧开，你就已经忘了谁要加糖、谁要杏仁奶。",
+      "solutionTitle": "解决之道",
+      "solutionText": "My Tiny Café 把精品咖啡馆的那份惊喜带进你的客厅，让这一刻变得特别起来。"
+    },
+    "howItWorks": {
+      "title": "如何使用（三个简单步骤）",
+      "step1Title": "1. 搭建你的菜单",
+      "step1Text": "给你的咖啡馆起个名字。加上你的招牌——拿铁、花草茶或法式吐司。自定义牛奶和糖的选项。",
+      "step2Title": "2. 分享链接",
+      "step2Text": "把二维码打印出来贴在冰箱上，或者直接发链接。客人随意浏览，按自己的喜好定制饮品。",
+      "step3Title": "3. 收到通知，开始上菜",
+      "step3Text": "叮！你会立刻收到通知。无需金钱往来——只有一杯完美的饮品，配上一个微笑。"
+    },
+    "features": {
+      "title": "功能特色",
+      "feature1Title": "完全自定义的菜单",
+      "feature1Text": "从「哺乳花草茶」到「冰抹茶」，由你决定端上什么。",
+      "feature2Title": "即时推送通知",
+      "feature2Text": "绝不漏掉任何一单。你的「顾客」一提交请求，你就立刻知道。",
+      "feature3Title": "无需下载任何应用",
+      "feature3Text": "客人扫一扫（或点一点）就能下单，无需安装。",
+      "feature4Title": "完全免费",
+      "feature4Text": "没有支付通道，这里唯一的货币是感激之情。"
+    },
+    "stories": {
+      "title": "真实故事",
+      "quote1": "爸爸，我能用你的应用点一杯茶吗？",
+      "quote1Name": "Zola，5 岁",
+      "quote1Role": "首席品鉴官",
+      "quote2": "回家前先点一杯咖啡真是太方便了。而且这位咖啡师还超级可爱！",
+      "quote2Name": "Magali",
+      "quote2Role": "妻子兼忠实顾客"
+    },
+    "audience": {
+      "title": "My Tiny Café 适合谁？",
+      "card1Title": "远程办公的神仙眷侣",
+      "card1Text": "无需打断 Zoom 会议，悄悄下单来一剂咖啡因。",
+      "card2Title": "「最会待客的主人」",
+      "card2Text": "让客人通过电子菜单点上一杯餐后助消化饮品，惊艳全场。",
+      "card3Title": "爱玩的爸妈",
+      "card3Text": "孩子们都爱玩「开餐厅」。把菜单设置好交给他们，让他们来为你点单。"
+    },
+    "faq": {
+      "title": "常见问题",
+      "q1": "真的免费吗？",
+      "a1": "是的！My Tiny Café 目前完全免费使用。",
+      "q2": "我可以卖饮品收钱吗？",
+      "a2": "不行。这个应用是为亲朋好友设计的，不涉及任何支付处理——只有为你在乎的人端上一杯饮品的那份喜悦。",
+      "q3": "菜单上能放什么？",
+      "a3": "什么都行！咖啡、茶、点心、法式吐司、白开水……只要你能在厨房里做出来，就能放进你的菜单。"
+    },
+    "openSource": {
+      "title": "自豪地开源",
+      "text": "我相信透明与社区的力量。My Tiny Café 是开源的，你可以清楚地看到它是如何构建的，贡献新功能，或者自行部署。",
+      "button": "在 GitHub 上查看"
+    },
+    "footer": {
+      "title": "准备好开张了吗？",
+      "subtitle": "今天就加入居家咖啡师的社区吧。",
+      "cta": "立即创建你的咖啡馆",
+      "madeWith": "在法国用 ❤️ 为 Zola 和 Magali 倾心打造。",
+      "copyright": "© 2024 My Tiny Café",
+      "aboutMakerTitle": "关于作者",
+      "aboutMakerText": "我是 Alix，做这个是为了让我的妻子和女儿开心。希望它也能为你的家带来一点欢乐。我是一名前端自由开发者（尤其擅长 Vue.js / Nuxt.js），有人机交互研究的背景。{link}。",
+      "aboutMakerLink": "看看我的作品",
+      "guest": "是访客？",
+      "findCafe": "找一家咖啡馆"
+    }
+  },
+  "auth": {
+    "fields": {
+      "emailLabel": "邮箱",
+      "emailPlaceholder": "you{'@'}example.com",
+      "emailFloating": "邮箱",
+      "passwordLabel": "密码",
+      "passwordFloating": "密码",
+      "nameLabel": "姓名",
+      "namePlaceholder": "你的名字",
+      "nameFloating": "你的名字",
+      "cafeIdLabel": "咖啡馆 ID",
+      "cafeIdPlaceholder": "咖啡馆 ID",
+      "cafeIdFloating": "你的咖啡馆 ID"
+    },
+    "validation": {
+      "invalidEmail": "邮箱地址无效",
+      "passwordMin": "密码至少需要 8 个字符",
+      "nameMin": "姓名至少需要 2 个字符",
+      "cafeIdMin": "咖啡馆 ID 至少需要 3 个字符"
+    },
+    "login": {
+      "title": "登录",
+      "submit": "登录",
+      "noAccount": "还没有账号？",
+      "signupLink": "注册",
+      "successTitle": "登录成功！",
+      "successDesc": "正在跳转……",
+      "failTitle": "登录失败",
+      "errorUnexpected": "发生了意外错误，请重试。"
+    },
+    "signup": {
+      "title": "创建账号",
+      "submit": "注册",
+      "haveAccount": "已经有账号了？",
+      "loginLink": "登录",
+      "accountCreatedTitle": "账号已创建！",
+      "accountCreatedDesc": "请登录以继续。",
+      "invalidCafeIdTitle": "无效的咖啡馆 ID",
+      "invalidCafeIdDesc": "咖啡馆 ID 不能为「undefined」。请换一个咖啡馆 ID。",
+      "cafeIdExistsTitle": "咖啡馆 ID 已存在",
+      "cafeIdExistsDesc": "请换一个咖啡馆 ID。",
+      "failTitle": "注册失败",
+      "failDesc": "发生了意外错误。"
+    }
+  },
+  "setup": {
+    "title": "完成咖啡馆设置",
+    "intro": "看起来在设置咖啡馆时出了点问题。请提供你的咖啡馆信息以继续。",
+    "cafeNameLabel": "咖啡馆名称",
+    "cafeNamePlaceholder": "我的超棒咖啡馆",
+    "cafeNameFloating": "咖啡馆名称",
+    "noSpecialChars": "你的咖啡馆名称不能包含特殊字符或空格。",
+    "cafeIdLabel": "咖啡馆 ID",
+    "cafeIdPlaceholder": "cafe-id",
+    "cafeIdFloating": "你的咖啡馆 ID",
+    "submit": "完成设置",
+    "cafeFoundTitle": "已找到咖啡馆",
+    "cafeFoundDesc": "正在跳转到你的咖啡馆……",
+    "authErrorTitle": "认证错误",
+    "authErrorDesc": "你需要登录后才能完成设置。",
+    "cafeIdExistsTitle": "咖啡馆 ID 已存在",
+    "cafeIdExistsDesc": "请换一个咖啡馆 ID。",
+    "invalidCafeIdTitle": "无效的咖啡馆 ID",
+    "invalidCafeIdDesc": "咖啡馆 ID 不能为「undefined」。请换一个咖啡馆 ID。",
+    "completeTitle": "设置完成！",
+    "completeDesc": "你的咖啡馆已就绪。",
+    "failTitle": "设置失败",
+    "failDesc": "发生了意外错误。",
+    "validation": {
+      "nameMin": "姓名至少需要 2 个字符",
+      "cafeIdMin": "咖啡馆 ID 至少需要 3 个字符"
+    }
+  },
+  "menu": {
+    "beBarista": "成为咖啡师",
+    "heading": "菜单",
+    "pastOrders": "历史订单",
+    "unknownItem": "未知商品",
+    "yourName": "你的名字",
+    "order": "下单",
+    "anonymous": "匿名",
+    "status": {
+      "ordered": "你的订单正在准备中",
+      "completed": "你的订单已就绪！",
+      "canceled": "你的订单已取消",
+      "unknown": "状态未知"
+    },
+    "toast": {
+      "orderSentTitle": "订单已发送",
+      "orderSentDesc": "你的订单已成功发送。",
+      "errorTitle": "错误",
+      "orderFailDesc": "订单发送失败，请重试。",
+      "orderCanceledTitle": "订单已取消",
+      "orderCanceledDesc": "你的订单已成功取消。",
+      "cancelFailDesc": "取消订单失败，请重试。"
+    },
+    "headDescription": "在 {cafeName} 点上你最爱的美食"
+  },
+  "baristaOrders": {
+    "title": "订单",
+    "enableNotifications": "有新订单时收到通知",
+    "emptyTitle": "暂无订单",
+    "emptyText": "分享你的咖啡馆页面，开始接单吧！",
+    "shareCafe": "分享我的咖啡馆",
+    "pastOrders": "历史订单",
+    "cancel": "取消",
+    "complete": "完成",
+    "unknownItem": "未知商品",
+    "statusLabel": {
+      "ordered": "已下单",
+      "completed": "已完成",
+      "canceled": "已取消"
+    }
+  },
+  "baristaMenu": {
+    "manageMenuFor": "管理 {cafeName} 的菜单",
+    "cafeId": "咖啡馆 ID：{id}",
+    "addNewItem": "添加新商品",
+    "noItemsTitle": "暂无商品",
+    "noItemsText": "添加一个新菜单商品来开始吧。",
+    "options": "选项：",
+    "yesNo": "是 / 否",
+    "noOptions": "未定义具体选项。",
+    "edit": "编辑",
+    "delete": "删除",
+    "editItemTitle": "编辑 {name}",
+    "addItemTitle": "添加新商品",
+    "itemNamePlaceholder": "例如：浓缩咖啡、可颂",
+    "itemNameFloating": "商品名称",
+    "pricePlaceholder": "例如：3.50",
+    "priceFloating": "价格",
+    "imageLabel": "图片",
+    "noImage": "无图片",
+    "descriptionPlaceholder": "商品描述……",
+    "descriptionFloating": "描述",
+    "optionNamePlaceholder": "例如：杯型、牛奶、低咖啡因",
+    "optionNameFloating": "选项名称",
+    "multipleValues": "多个取值 / 简单选项",
+    "valuesFor": "{name} 的取值：",
+    "thisOption": "此选项",
+    "valuePlaceholder": "例如：小杯、大杯、燕麦奶",
+    "valueFloating": "取值",
+    "addValue": "添加取值",
+    "addNewOptionType": "添加新的选项类型",
+    "removeOption": "移除选项",
+    "removeValue": "移除取值",
+    "cancel": "取消",
+    "saveChanges": "保存更改",
+    "addItem": "添加商品",
+    "confirmDelete": "确定要删除这个商品吗？此操作无法撤销。",
+    "images": {
+      "bobba": "珍珠奶茶",
+      "cafe": "咖啡",
+      "cookie": "曲奇",
+      "emporter": "外带",
+      "gaiwan": "盖碗",
+      "jus": "果汁",
+      "latte": "拿铁",
+      "muffin": "玛芬",
+      "mug": "马克杯",
+      "tartine": "法式吐司",
+      "the": "茶",
+      "yaourt": "酸奶"
+    },
+    "toast": {
+      "errorLoadingCafeTitle": "加载咖啡馆失败",
+      "errorLoadingCafeDesc": "找不到或无法加载所请求的咖啡馆。",
+      "errorLoadingMenuTitle": "加载菜单失败",
+      "errorLoadingMenuDesc": "无法加载菜单商品。",
+      "errorTitle": "错误",
+      "cafeIdMissing": "缺少咖啡馆 ID。",
+      "itemDeletedTitle": "商品已删除",
+      "itemDeletedDesc": "该商品已成功删除。",
+      "deletionFailedTitle": "删除失败",
+      "deletionFailedDesc": "无法删除该商品。",
+      "validationErrorTitle": "校验错误",
+      "itemNameRequired": "商品名称为必填项。",
+      "itemUpdatedTitle": "商品已更新",
+      "itemUpdatedDesc": "更改已成功保存。",
+      "itemAddedTitle": "商品已添加",
+      "itemAddedDesc": "新商品已添加到菜单。",
+      "saveFailedTitle": "保存失败",
+      "saveFailedDesc": "无法保存该商品。"
+    }
+  },
+  "cafeSettings": {
+    "share": {
+      "title": "分享你的页面",
+      "subtitle": "使用下方的网址或二维码分享此页面。",
+      "pageUrlLabel": "页面网址",
+      "pageUrlHelp": "这是通往你页面的直达链接。",
+      "generatingUrl": "正在生成网址……"
+    },
+    "qr": {
+      "title": "二维码",
+      "subtitle": "用移动设备扫描此二维码即可打开页面。",
+      "downloadPng": "下载 PNG",
+      "unavailable": "页面网址不可用，无法生成二维码。"
+    },
+    "updateName": {
+      "title": "更新咖啡馆名称",
+      "subtitle": "修改你咖啡馆的名称。",
+      "label": "咖啡馆名称",
+      "help": "为你的咖啡馆输入新名称。",
+      "placeholder": "输入新的咖啡馆名称",
+      "update": "更新",
+      "updating": "更新中……"
+    },
+    "customImages": {
+      "title": "自定义图片",
+      "subtitle": "上传你自己的图片，用于菜单商品。",
+      "upload": "上传图片",
+      "empty": "还没有自定义图片。上传一张来开始吧。"
+    },
+    "about": {
+      "title": "关于与支持",
+      "openSourceTitle": "开源",
+      "openSourceText": "本项目算是开源的。GitHub 上提供的 Appwrite 服务器配置可能已经过时，如有需要请随时联系我。",
+      "viewOnGithub": "在 GitHub 上查看",
+      "contactTitle": "联系作者",
+      "contactText": "由 Alix 打造。如有需要请随时联系。",
+      "hireText": "要不要请我为你的下一个项目效力？",
+      "supportTitle": "支持 My Tiny Café",
+      "supportText": "My Tiny Café 免费提供，但如果你喜欢使用它，欢迎赞助一点托管费用。",
+      "supportButton": "在 Buy Me a Coffee 上支持"
+    },
+    "delete": {
+      "title": "删除账号",
+      "subtitle": "永久删除你的咖啡馆、菜单、所有订单、所有自定义图片以及你的账号。此操作无法撤销。",
+      "button": "删除我的账号",
+      "modalTitle": "永久删除你的账号？",
+      "modalIntro": "这将永久删除：",
+      "modalListCafe": "你的咖啡馆 {id}",
+      "modalListMenu": "其菜单商品和所有历史订单",
+      "modalListImages": "你的自定义图片",
+      "modalListAccount": "你的账号（你将无法再次登录）",
+      "confirmLabel": "输入「{cafeId}」以确认",
+      "deletePermanently": "永久删除"
+    },
+    "session": {
+      "title": "会话",
+      "subtitle": "退出此设备的登录。你随时可以重新登录。",
+      "logout": "退出登录"
+    },
+    "toast": {
+      "imageUploadedTitle": "图片已上传",
+      "imageUploadedDesc": "「{name}」已上传。",
+      "uploadFailedTitle": "上传失败",
+      "uploadFailedDesc": "无法上传图片。",
+      "confirmDeleteImage": "删除这张图片吗？使用它的商品将显示一张破损的图片。",
+      "imageDeletedTitle": "图片已删除",
+      "imageDeletedDesc": "图片已删除。",
+      "deleteFailedTitle": "删除失败",
+      "deleteFailedDesc": "无法删除图片。",
+      "errorTitle": "错误",
+      "cafeIdUnavailable": "咖啡馆 ID 不可用，无法更新名称。",
+      "validationErrorTitle": "校验错误",
+      "cafeNameEmpty": "咖啡馆名称不能为空。",
+      "successTitle": "成功！",
+      "cafeNameUpdated": "咖啡馆名称已更新为「{name}」。",
+      "updateFailedTitle": "更新失败",
+      "updateNameFailedDesc": "无法更新咖啡馆名称，请重试。",
+      "missingCafeIdTitle": "缺少咖啡馆 ID",
+      "missingCafeIdDesc": "网址中缺少咖啡馆的唯一标识符。",
+      "urlNotAvailableTitle": "网址不可用",
+      "urlNotAvailableDesc": "页面网址尚未准备好，无法复制。",
+      "clipboardDeniedTitle": "剪贴板访问被拒绝",
+      "clipboardDeniedDesc": "你的浏览器设置阻止了剪贴板访问，或不支持该功能。",
+      "urlCopiedTitle": "网址已复制！",
+      "urlCopiedDesc": "页面网址已复制到你的剪贴板。",
+      "copyUnconfirmedTitle": "复制未确认",
+      "copyUnconfirmedDesc": "已尝试复制。请检查你的剪贴板。",
+      "copyFailedTitle": "复制失败",
+      "copyFailedDesc": "复制网址时出错，请手动复制。",
+      "downloadFailedTitle": "下载失败",
+      "qrNotReady": "二维码尚未准备好，请重试。",
+      "qrDownloadedTitle": "二维码已下载",
+      "qrDownloadedDesc": "二维码 PNG 已保存。",
+      "qrGenerateFailed": "无法生成 PNG 文件，请重试。",
+      "loggedOutTitle": "已退出登录",
+      "loggedOutDesc": "你已退出登录",
+      "accountDeletedTitle": "账号已删除",
+      "accountDeletedDesc": "你的账号和咖啡馆已被永久删除。",
+      "deletionFailedTitle": "删除失败",
+      "deletionFailedDesc": "无法删除你的账号，请重试。"
+    }
+  },
+  "invalidCafe": {
+    "title": "这家咖啡馆打烊了。",
+    "text": "我们在这个地址找不到任何咖啡馆。也许是链接错了——又或者，是时候轮到{you}开一家自己的了？",
+    "textHighlight": "你",
+    "openOwn": "开一家我自己的咖啡馆",
+    "backHome": "返回首页",
+    "noCreditCard": "无需信用卡，没有广告，只有满满的爱。",
+    "headTitle": "找不到咖啡馆 — My Tiny Café"
+  },
+  "pwa": {
+    "finding": "正在寻找你的角落……",
+    "redirecting": "正在带你前往上次访问的咖啡馆。"
+  },
+  "demo": {
+    "cafeName": "Chez Zola",
+    "promptTitle": "想拥有属于自己的家庭咖啡馆吗？",
+    "promptText": "如果你也想为亲朋好友开一家自己的小咖啡馆，那就注册吧——完全免费，没有广告，大约一分钟就能搞定。",
+    "openCafe": "开一家我的小咖啡馆",
+    "keepBrowsing": "继续浏览",
+    "items": {
+      "latte": {
+        "name": "拿铁",
+        "description": "丝滑浓缩咖啡，覆上绵密蒸奶。",
+        "price": "一个拥抱 🤗"
+      },
+      "espresso": {
+        "name": "浓缩咖啡",
+        "description": "短小、深沉、浓烈。经典之选。"
+      },
+      "matcha": {
+        "name": "抹茶",
+        "description": "现点现打的仪式级绿茶。"
+      },
+      "tea": {
+        "name": "茶",
+        "description": "散叶茶，现点现泡。"
+      },
+      "juice": {
+        "name": "鲜榨果汁",
+        "description": "今早现榨。"
+      },
+      "bubble": {
+        "name": "珍珠奶茶",
+        "description": "Q弹珍珠，你最爱的口味。"
+      },
+      "muffin": {
+        "name": "玛芬",
+        "description": "今早现烤。"
+      },
+      "cookie": {
+        "name": "曲奇",
+        "description": "温热又有嚼劲。"
+      },
+      "tartine": {
+        "name": "法式吐司",
+        "description": "酸种面包，烤得香脆，配上各式佐料。"
+      },
+      "yogurt": {
+        "name": "酸奶",
+        "description": "希腊酸奶，新鲜水果，格兰诺拉麦片。",
+        "price": "免费！"
+      }
+    }
+  }
+}

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -4,12 +4,39 @@ import tailwindcss from "@tailwindcss/vite";
 export default defineNuxtConfig({
   compatibilityDate: "2026-01-01",
   // https://nuxt.com/modules
-  modules: ['@nuxthub/core', '@nuxt/eslint', '@nuxt/ui', '@vite-pwa/nuxt', '@nuxt/image'],
+  modules: ['@nuxthub/core', '@nuxt/eslint', '@nuxt/ui', '@vite-pwa/nuxt', '@nuxt/image', '@nuxtjs/i18n'],
   css: ['~/assets/css/main.css'],
+  // https://i18n.nuxtjs.org — multilingual (en, fr, de, es, it, zh)
+  i18n: {
+    strategy: 'no_prefix',
+    defaultLocale: 'en',
+    locales: [
+      { code: 'en', name: 'English', language: 'en-US', file: 'en.json' },
+      { code: 'fr', name: 'Français', language: 'fr-FR', file: 'fr.json' },
+      { code: 'de', name: 'Deutsch', language: 'de-DE', file: 'de.json' },
+      { code: 'es', name: 'Español', language: 'es-ES', file: 'es.json' },
+      { code: 'it', name: 'Italiano', language: 'it-IT', file: 'it.json' },
+      { code: 'zh', name: '中文', language: 'zh-CN', file: 'zh.json' },
+    ],
+    lazy: true,
+    langDir: 'locales',
+    vueI18n: './i18n.config.ts',
+    bundle: {
+      // Recommended by the module; avoids the deprecated translation-directive optimizer.
+      optimizeTranslationDirective: false,
+    },
+    detectBrowserLanguage: {
+      useCookie: true,
+      cookieKey: 'i18n_locale',
+      redirectOn: 'root',
+      fallbackLocale: 'en',
+    },
+  },
   // https://devtools.nuxt.com
   devtools: { enabled: true },
   vite: {
-    plugins: [tailwindcss()]
+    // `as any` works around duplicate vite type identities after adding @nuxtjs/i18n
+    plugins: [tailwindcss() as any]
   },
   // Env variables - https://nuxt.com/docs/getting-started/configuration#environment-variables-and-private-tokens
   runtimeConfig: {

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "@nuxt/image": "2.0.0",
     "@nuxt/ui": "^3.1.0",
     "@nuxthub/core": "^0.10.4",
+    "@nuxtjs/i18n": "^9.5.6",
     "@tailwindcss/vite": "^4.1.5",
     "@vite-pwa/nuxt": "1.0.0",
     "appwrite": "^17.0.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,22 +10,25 @@ importers:
     dependencies:
       '@nuxt/eslint':
         specifier: ^1.3.0
-        version: 1.3.0(@vue/compiler-sfc@3.5.13)(eslint@9.25.1(jiti@2.6.1))(magicast@0.3.5)(typescript@5.8.3)(vite@6.3.4(@types/node@22.15.3)(jiti@2.6.1)(lightningcss@1.29.2)(terser@5.39.0)(yaml@2.7.1))
+        version: 1.3.0(@vue/compiler-sfc@3.5.35)(eslint@9.25.1(jiti@2.6.1))(magicast@0.3.5)(typescript@5.8.3)(vite@6.3.4(@types/node@22.15.3)(jiti@2.6.1)(lightningcss@1.29.2)(terser@5.39.0)(yaml@2.9.0))
       '@nuxt/image':
         specifier: 2.0.0
         version: 2.0.0(@netlify/blobs@8.2.0)(db0@0.3.2)(ioredis@5.6.1)(magicast@0.3.5)
       '@nuxt/ui':
         specifier: ^3.1.0
-        version: 3.1.0(@babel/parser@7.28.5)(@netlify/blobs@8.2.0)(change-case@5.4.4)(db0@0.3.2)(embla-carousel@8.6.0)(ioredis@5.6.1)(jwt-decode@4.0.0)(magicast@0.3.5)(typescript@5.8.3)(vite@6.3.4(@types/node@22.15.3)(jiti@2.6.1)(lightningcss@1.29.2)(terser@5.39.0)(yaml@2.7.1))(vue-router@4.5.1(vue@3.5.13(typescript@5.8.3)))(vue@3.5.13(typescript@5.8.3))(zod@3.24.3)
+        version: 3.1.0(@babel/parser@7.29.7)(@netlify/blobs@8.2.0)(change-case@5.4.4)(db0@0.3.2)(embla-carousel@8.6.0)(ioredis@5.6.1)(jwt-decode@4.0.0)(magicast@0.3.5)(typescript@5.8.3)(vite@6.3.4(@types/node@22.15.3)(jiti@2.6.1)(lightningcss@1.29.2)(terser@5.39.0)(yaml@2.9.0))(vue-router@4.5.1(vue@3.5.13(typescript@5.8.3)))(vue@3.5.13(typescript@5.8.3))(zod@3.24.3)
       '@nuxthub/core':
         specifier: ^0.10.4
         version: 0.10.4(@netlify/blobs@8.2.0)(db0@0.3.2)(ioredis@5.6.1)(magicast@0.3.5)(typescript@5.8.3)(vue-tsc@2.2.10(typescript@5.8.3))
+      '@nuxtjs/i18n':
+        specifier: ^9.5.6
+        version: 9.5.6(@vue/compiler-dom@3.5.35)(eslint@9.25.1(jiti@2.6.1))(magicast@0.3.5)(rollup@4.40.1)(vue@3.5.13(typescript@5.8.3))
       '@tailwindcss/vite':
         specifier: ^4.1.5
-        version: 4.1.5(vite@6.3.4(@types/node@22.15.3)(jiti@2.6.1)(lightningcss@1.29.2)(terser@5.39.0)(yaml@2.7.1))
+        version: 4.1.5(vite@6.3.4(@types/node@22.15.3)(jiti@2.6.1)(lightningcss@1.29.2)(terser@5.39.0)(yaml@2.9.0))
       '@vite-pwa/nuxt':
         specifier: 1.0.0
-        version: 1.0.0(@vite-pwa/assets-generator@1.0.0)(magicast@0.3.5)(vite@6.3.4(@types/node@22.15.3)(jiti@2.6.1)(lightningcss@1.29.2)(terser@5.39.0)(yaml@2.7.1))(workbox-build@7.3.0)(workbox-window@7.3.0)
+        version: 1.0.0(@vite-pwa/assets-generator@1.0.0)(magicast@0.3.5)(vite@6.3.4(@types/node@22.15.3)(jiti@2.6.1)(lightningcss@1.29.2)(terser@5.39.0)(yaml@2.9.0))(workbox-build@7.3.0)(workbox-window@7.3.0)
       appwrite:
         specifier: ^17.0.2
         version: 17.0.2
@@ -34,7 +37,7 @@ importers:
         version: 11.6.1
       nuxt:
         specifier: ^3.17.1
-        version: 3.17.1(@netlify/blobs@8.2.0)(@parcel/watcher@2.5.1)(@types/node@22.15.3)(db0@0.3.2)(eslint@9.25.1(jiti@2.6.1))(ioredis@5.6.1)(lightningcss@1.29.2)(magicast@0.3.5)(optionator@0.9.4)(rolldown@1.0.0-beta.57)(rollup@4.40.1)(terser@5.39.0)(typescript@5.8.3)(vite@6.3.4(@types/node@22.15.3)(jiti@2.6.1)(lightningcss@1.29.2)(terser@5.39.0)(yaml@2.7.1))(vue-tsc@2.2.10(typescript@5.8.3))(yaml@2.7.1)
+        version: 3.17.1(@netlify/blobs@8.2.0)(@parcel/watcher@2.5.1)(@types/node@22.15.3)(db0@0.3.2)(eslint@9.25.1(jiti@2.6.1))(ioredis@5.6.1)(lightningcss@1.29.2)(magicast@0.3.5)(optionator@0.9.4)(rolldown@1.0.0-beta.57)(rollup@4.40.1)(terser@5.39.0)(typescript@5.8.3)(vite@6.3.4(@types/node@22.15.3)(jiti@2.6.1)(lightningcss@1.29.2)(terser@5.39.0)(yaml@2.9.0))(vue-tsc@2.2.10(typescript@5.8.3))(yaml@2.9.0)
       qrcode.vue:
         specifier: ^3.6.0
         version: 3.6.0(vue@3.5.13(typescript@5.8.3))
@@ -50,7 +53,7 @@ importers:
     devDependencies:
       '@nuxt/eslint-config':
         specifier: ^1.3.0
-        version: 1.3.0(@vue/compiler-sfc@3.5.13)(eslint@9.25.1(jiti@2.6.1))(typescript@5.8.3)
+        version: 1.3.0(@vue/compiler-sfc@3.5.35)(eslint@9.25.1(jiti@2.6.1))(typescript@5.8.3)
       '@vite-pwa/assets-generator':
         specifier: ^1.0.0
         version: 1.0.0
@@ -180,12 +183,20 @@ packages:
     resolution: {integrity: sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/helper-string-parser@7.29.7':
+    resolution: {integrity: sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/helper-validator-identifier@7.27.1':
     resolution: {integrity: sha512-D2hP9eA+Sqx1kBZgzxZh0y1trbuU+JoDkiEwqhQ36nodYqJwyEIhPSdMNd7lOm/4io72luTPWH20Yda0xOuUow==}
     engines: {node: '>=6.9.0'}
 
   '@babel/helper-validator-identifier@7.28.5':
     resolution: {integrity: sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-validator-identifier@7.29.7':
+    resolution: {integrity: sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==}
     engines: {node: '>=6.9.0'}
 
   '@babel/helper-validator-option@7.27.1':
@@ -207,6 +218,11 @@ packages:
 
   '@babel/parser@7.28.5':
     resolution: {integrity: sha512-KKBU1VGYR7ORr3At5HAtUQ+TV3SzRCXmA/8OdDZiLDBIZxVyzXuztPjfLd3BV1PRAQGCMWWSHYhL0F8d5uHBDQ==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+
+  '@babel/parser@7.29.7':
+    resolution: {integrity: sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==}
     engines: {node: '>=6.0.0'}
     hasBin: true
 
@@ -617,6 +633,10 @@ packages:
     resolution: {integrity: sha512-qQ5m48eI/MFLQ5PxQj4PFaprjyCTLI37ElWMmNs0K8Lk3dVeOdNpB3ks8jc7yM5CDmVC73eMVk/trk3fgmrUpA==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/types@7.29.7':
+    resolution: {integrity: sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==}
+    engines: {node: '>=6.9.0'}
+
   '@canvas/image-data@1.0.0':
     resolution: {integrity: sha512-BxOqI5LgsIQP1odU5KMwV9yoijleOPzHL18/YvNqF9KFSGF2K/DLlYAbDQsWqd/1nbaFuSkYD/191dpMtNh4vw==}
 
@@ -718,6 +738,12 @@ packages:
     cpu: [ppc64]
     os: [aix]
 
+  '@esbuild/aix-ppc64@0.25.12':
+    resolution: {integrity: sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
   '@esbuild/aix-ppc64@0.25.2':
     resolution: {integrity: sha512-wCIboOL2yXZym2cgm6mlA742s9QeJ8DjGVaL39dLN4rRwrOgOyYSnOaFPhKZGLb2ngj4EyfAFjsNJwPXZvseag==}
     engines: {node: '>=18'}
@@ -733,6 +759,12 @@ packages:
   '@esbuild/android-arm64@0.19.11':
     resolution: {integrity: sha512-aiu7K/5JnLj//KOnOfEZ0D90obUkRzDMyqd/wNAUQ34m4YUPVhRZpnqKV9uqDGxT7cToSDnIHsGooyIczu9T+Q==}
     engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm64@0.25.12':
+    resolution: {integrity: sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==}
+    engines: {node: '>=18'}
     cpu: [arm64]
     os: [android]
 
@@ -754,6 +786,12 @@ packages:
     cpu: [arm]
     os: [android]
 
+  '@esbuild/android-arm@0.25.12':
+    resolution: {integrity: sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
   '@esbuild/android-arm@0.25.2':
     resolution: {integrity: sha512-NQhH7jFstVY5x8CKbcfa166GoV0EFkaPkCKBQkdPJFvo5u+nGXLEH/ooniLb3QI8Fk58YAx7nsPLozUWfCBOJA==}
     engines: {node: '>=18'}
@@ -769,6 +807,12 @@ packages:
   '@esbuild/android-x64@0.19.11':
     resolution: {integrity: sha512-eccxjlfGw43WYoY9QgB82SgGgDbibcqyDTlk3l3C0jOVHKxrjdc9CTwDUQd0vkvYg5um0OH+GpxYvp39r+IPOg==}
     engines: {node: '>=12'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/android-x64@0.25.12':
+    resolution: {integrity: sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [android]
 
@@ -790,6 +834,12 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
+  '@esbuild/darwin-arm64@0.25.12':
+    resolution: {integrity: sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
   '@esbuild/darwin-arm64@0.25.2':
     resolution: {integrity: sha512-MpM6LUVTXAzOvN4KbjzU/q5smzryuoNjlriAIx+06RpecwCkL9JpenNzpKd2YMzLJFOdPqBpuub6eVRP5IgiSA==}
     engines: {node: '>=18'}
@@ -805,6 +855,12 @@ packages:
   '@esbuild/darwin-x64@0.19.11':
     resolution: {integrity: sha512-fkFUiS6IUK9WYUO/+22omwetaSNl5/A8giXvQlcinLIjVkxwTLSktbF5f/kJMftM2MJp9+fXqZ5ezS7+SALp4g==}
     engines: {node: '>=12'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.25.12':
+    resolution: {integrity: sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [darwin]
 
@@ -826,6 +882,12 @@ packages:
     cpu: [arm64]
     os: [freebsd]
 
+  '@esbuild/freebsd-arm64@0.25.12':
+    resolution: {integrity: sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
   '@esbuild/freebsd-arm64@0.25.2':
     resolution: {integrity: sha512-mLwm4vXKiQ2UTSX4+ImyiPdiHjiZhIaE9QvC7sw0tZ6HoNMjYAqQpGyui5VRIi5sGd+uWq940gdCbY3VLvsO1w==}
     engines: {node: '>=18'}
@@ -841,6 +903,12 @@ packages:
   '@esbuild/freebsd-x64@0.19.11':
     resolution: {integrity: sha512-JkUqn44AffGXitVI6/AbQdoYAq0TEullFdqcMY/PCUZ36xJ9ZJRtQabzMA+Vi7r78+25ZIBosLTOKnUXBSi1Kw==}
     engines: {node: '>=12'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.25.12':
+    resolution: {integrity: sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [freebsd]
 
@@ -862,6 +930,12 @@ packages:
     cpu: [arm64]
     os: [linux]
 
+  '@esbuild/linux-arm64@0.25.12':
+    resolution: {integrity: sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
   '@esbuild/linux-arm64@0.25.2':
     resolution: {integrity: sha512-gq/sjLsOyMT19I8obBISvhoYiZIAaGF8JpeXu1u8yPv8BE5HlWYobmlsfijFIZ9hIVGYkbdFhEqC0NvM4kNO0g==}
     engines: {node: '>=18'}
@@ -877,6 +951,12 @@ packages:
   '@esbuild/linux-arm@0.19.11':
     resolution: {integrity: sha512-3CRkr9+vCV2XJbjwgzjPtO8T0SZUmRZla+UL1jw+XqHZPkPgZiyWvbDvl9rqAN8Zl7qJF0O/9ycMtjU67HN9/Q==}
     engines: {node: '>=12'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.25.12':
+    resolution: {integrity: sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==}
+    engines: {node: '>=18'}
     cpu: [arm]
     os: [linux]
 
@@ -898,6 +978,12 @@ packages:
     cpu: [ia32]
     os: [linux]
 
+  '@esbuild/linux-ia32@0.25.12':
+    resolution: {integrity: sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
   '@esbuild/linux-ia32@0.25.2':
     resolution: {integrity: sha512-bBYCv9obgW2cBP+2ZWfjYTU+f5cxRoGGQ5SeDbYdFCAZpYWrfjjfYwvUpP8MlKbP0nwZ5gyOU/0aUzZ5HWPuvQ==}
     engines: {node: '>=18'}
@@ -913,6 +999,12 @@ packages:
   '@esbuild/linux-loong64@0.19.11':
     resolution: {integrity: sha512-ppZSSLVpPrwHccvC6nQVZaSHlFsvCQyjnvirnVjbKSHuE5N24Yl8F3UwYUUR1UEPaFObGD2tSvVKbvR+uT1Nrg==}
     engines: {node: '>=12'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.25.12':
+    resolution: {integrity: sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==}
+    engines: {node: '>=18'}
     cpu: [loong64]
     os: [linux]
 
@@ -934,6 +1026,12 @@ packages:
     cpu: [mips64el]
     os: [linux]
 
+  '@esbuild/linux-mips64el@0.25.12':
+    resolution: {integrity: sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
   '@esbuild/linux-mips64el@0.25.2':
     resolution: {integrity: sha512-hDDRlzE6rPeoj+5fsADqdUZl1OzqDYow4TB4Y/3PlKBD0ph1e6uPHzIQcv2Z65u2K0kpeByIyAjCmjn1hJgG0Q==}
     engines: {node: '>=18'}
@@ -949,6 +1047,12 @@ packages:
   '@esbuild/linux-ppc64@0.19.11':
     resolution: {integrity: sha512-MHrZYLeCG8vXblMetWyttkdVRjQlQUb/oMgBNurVEnhj4YWOr4G5lmBfZjHYQHHN0g6yDmCAQRR8MUHldvvRDA==}
     engines: {node: '>=12'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.25.12':
+    resolution: {integrity: sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==}
+    engines: {node: '>=18'}
     cpu: [ppc64]
     os: [linux]
 
@@ -970,6 +1074,12 @@ packages:
     cpu: [riscv64]
     os: [linux]
 
+  '@esbuild/linux-riscv64@0.25.12':
+    resolution: {integrity: sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
   '@esbuild/linux-riscv64@0.25.2':
     resolution: {integrity: sha512-k4LtpgV7NJQOml/10uPU0s4SAXGnowi5qBSjaLWMojNCUICNu7TshqHLAEbkBdAszL5TabfvQ48kK84hyFzjnw==}
     engines: {node: '>=18'}
@@ -985,6 +1095,12 @@ packages:
   '@esbuild/linux-s390x@0.19.11':
     resolution: {integrity: sha512-A5xdUoyWJHMMlcSMcPGVLzYzpcY8QP1RtYzX5/bS4dvjBGVxdhuiYyFwp7z74ocV7WDc0n1harxmpq2ePOjI0Q==}
     engines: {node: '>=12'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.25.12':
+    resolution: {integrity: sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==}
+    engines: {node: '>=18'}
     cpu: [s390x]
     os: [linux]
 
@@ -1006,6 +1122,12 @@ packages:
     cpu: [x64]
     os: [linux]
 
+  '@esbuild/linux-x64@0.25.12':
+    resolution: {integrity: sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
   '@esbuild/linux-x64@0.25.2':
     resolution: {integrity: sha512-QInHERlqpTTZ4FRB0fROQWXcYRD64lAoiegezDunLpalZMjcUcld3YzZmVJ2H/Cp0wJRZ8Xtjtj0cEHhYc/uUg==}
     engines: {node: '>=18'}
@@ -1017,6 +1139,12 @@ packages:
     engines: {node: '>=18'}
     cpu: [x64]
     os: [linux]
+
+  '@esbuild/netbsd-arm64@0.25.12':
+    resolution: {integrity: sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
 
   '@esbuild/netbsd-arm64@0.25.2':
     resolution: {integrity: sha512-talAIBoY5M8vHc6EeI2WW9d/CkiO9MQJ0IOWX8hrLhxGbro/vBXJvaQXefW2cP0z0nQVTdQ/eNyGFV1GSKrxfw==}
@@ -1036,6 +1164,12 @@ packages:
     cpu: [x64]
     os: [netbsd]
 
+  '@esbuild/netbsd-x64@0.25.12':
+    resolution: {integrity: sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
   '@esbuild/netbsd-x64@0.25.2':
     resolution: {integrity: sha512-voZT9Z+tpOxrvfKFyfDYPc4DO4rk06qamv1a/fkuzHpiVBMOhpjK+vBmWM8J1eiB3OLSMFYNaOaBNLXGChf5tg==}
     engines: {node: '>=18'}
@@ -1047,6 +1181,12 @@ packages:
     engines: {node: '>=18'}
     cpu: [x64]
     os: [netbsd]
+
+  '@esbuild/openbsd-arm64@0.25.12':
+    resolution: {integrity: sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
 
   '@esbuild/openbsd-arm64@0.25.2':
     resolution: {integrity: sha512-dcXYOC6NXOqcykeDlwId9kB6OkPUxOEqU+rkrYVqJbK2hagWOMrsTGsMr8+rW02M+d5Op5NNlgMmjzecaRf7Tg==}
@@ -1066,6 +1206,12 @@ packages:
     cpu: [x64]
     os: [openbsd]
 
+  '@esbuild/openbsd-x64@0.25.12':
+    resolution: {integrity: sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
   '@esbuild/openbsd-x64@0.25.2':
     resolution: {integrity: sha512-t/TkWwahkH0Tsgoq1Ju7QfgGhArkGLkF1uYz8nQS/PPFlXbP5YgRpqQR3ARRiC2iXoLTWFxc6DJMSK10dVXluw==}
     engines: {node: '>=18'}
@@ -1078,9 +1224,21 @@ packages:
     cpu: [x64]
     os: [openbsd]
 
+  '@esbuild/openharmony-arm64@0.25.12':
+    resolution: {integrity: sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
   '@esbuild/sunos-x64@0.19.11':
     resolution: {integrity: sha512-Hf+Sad9nVwvtxy4DXCZQqLpgmRTQqyFyhT3bZ4F2XlJCjxGmRFF0Shwn9rzhOYRB61w9VMXUkxlBy56dk9JJiQ==}
     engines: {node: '>=12'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/sunos-x64@0.25.12':
+    resolution: {integrity: sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [sunos]
 
@@ -1102,6 +1260,12 @@ packages:
     cpu: [arm64]
     os: [win32]
 
+  '@esbuild/win32-arm64@0.25.12':
+    resolution: {integrity: sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
   '@esbuild/win32-arm64@0.25.2':
     resolution: {integrity: sha512-7Loyjh+D/Nx/sOTzV8vfbB3GJuHdOQyrOryFdZvPHLf42Tk9ivBU5Aedi7iyX+x6rbn2Mh68T4qq1SDqJBQO5Q==}
     engines: {node: '>=18'}
@@ -1120,6 +1284,12 @@ packages:
     cpu: [ia32]
     os: [win32]
 
+  '@esbuild/win32-ia32@0.25.12':
+    resolution: {integrity: sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
   '@esbuild/win32-ia32@0.25.2':
     resolution: {integrity: sha512-WRJgsz9un0nqZJ4MfhabxaD9Ft8KioqU3JMinOTvobbX6MOSUigSBlogP8QB3uxpJDsFS6yN+3FDBdqE5lg9kg==}
     engines: {node: '>=18'}
@@ -1135,6 +1305,12 @@ packages:
   '@esbuild/win32-x64@0.19.11':
     resolution: {integrity: sha512-vfkhltrjCAb603XaFhqhAF4LGDi2M4OrCRrFusyQ+iTLQ/o60QQXxc9cZC/FFpihBI9N1Grn6SMKVJ4KP7Fuiw==}
     engines: {node: '>=12'}
+    cpu: [x64]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.25.12':
+    resolution: {integrity: sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
 
@@ -1726,6 +1902,81 @@ packages:
   '@internationalized/number@3.6.1':
     resolution: {integrity: sha512-UVsb4bCwbL944E0SX50CHFtWEeZ2uB5VozZ5yDXJdq6iPZsZO5p+bjVMZh2GxHf4Bs/7xtDCcPwEa2NU9DaG/g==}
 
+  '@intlify/bundle-utils@10.0.1':
+    resolution: {integrity: sha512-WkaXfSevtpgtUR4t8K2M6lbR7g03mtOxFeh+vXp5KExvPqS12ppaRj1QxzwRuRI5VUto54A22BjKoBMLyHILWQ==}
+    engines: {node: '>= 18'}
+    peerDependencies:
+      petite-vue-i18n: '*'
+      vue-i18n: '*'
+    peerDependenciesMeta:
+      petite-vue-i18n:
+        optional: true
+      vue-i18n:
+        optional: true
+
+  '@intlify/core-base@10.0.8':
+    resolution: {integrity: sha512-FoHslNWSoHjdUBLy35bpm9PV/0LVI/DSv9L6Km6J2ad8r/mm0VaGg06C40FqlE8u2ADcGUM60lyoU7Myo4WNZQ==}
+    engines: {node: '>= 16'}
+
+  '@intlify/core@10.0.8':
+    resolution: {integrity: sha512-2BbgN0aeuYHOHe7kVlTr2XxyrnLQZ/4/Y0Pw8luU67723+AqVYqxB7ZG1FzLCVNwAmzdVZMjKzFpgOzdUSdBfw==}
+    engines: {node: '>= 16'}
+
+  '@intlify/h3@0.6.1':
+    resolution: {integrity: sha512-hFMcqWXCoFNZkraa+JF7wzByGdE0vGi8rUs7CTFrE4hE3X2u9QcelH8VRO8mPgJDH+TgatzvrVp6iZsWVluk2A==}
+    engines: {node: '>= 18'}
+
+  '@intlify/message-compiler@10.0.8':
+    resolution: {integrity: sha512-DV+sYXIkHVd5yVb2mL7br/NEUwzUoLBsMkV3H0InefWgmYa34NLZUvMCGi5oWX+Hqr2Y2qUxnVrnOWF4aBlgWg==}
+    engines: {node: '>= 16'}
+
+  '@intlify/message-compiler@11.4.4':
+    resolution: {integrity: sha512-vn0OAV9pYkJlPPmgnsSm5eAG3mL0+9C/oaded2JY9jmxBbhmUXT3TcAUY8WRgLY9Hte7lkUJKpXrVlYjMXBD2w==}
+    engines: {node: '>= 22'}
+
+  '@intlify/shared@10.0.8':
+    resolution: {integrity: sha512-BcmHpb5bQyeVNrptC3UhzpBZB/YHHDoEREOUERrmF2BRxsyOEuRrq+Z96C/D4+2KJb8kuHiouzAei7BXlG0YYw==}
+    engines: {node: '>= 16'}
+
+  '@intlify/shared@11.4.4':
+    resolution: {integrity: sha512-QRUCHqda1U6aR14FR0vvXD4+4gj6+fm0AhAozvSuRCw0fCvrmCugWpgiR4xH2NI6s8am6N9p5OhirplsX8ZS3g==}
+    engines: {node: '>= 22'}
+
+  '@intlify/unplugin-vue-i18n@6.0.8':
+    resolution: {integrity: sha512-Vvm3KhjE6TIBVUQAk37rBiaYy2M5OcWH0ZcI1XKEsOTeN1o0bErk+zeuXmcrcMc/73YggfI8RoxOUz9EB/69JQ==}
+    engines: {node: '>= 18'}
+    peerDependencies:
+      petite-vue-i18n: '*'
+      vue: ^3.2.25
+      vue-i18n: '*'
+    peerDependenciesMeta:
+      petite-vue-i18n:
+        optional: true
+      vue-i18n:
+        optional: true
+
+  '@intlify/utils@0.13.0':
+    resolution: {integrity: sha512-8i3uRdAxCGzuHwfmHcVjeLQBtysQB2aXl/ojoagDut5/gY5lvWCQ2+cnl2TiqE/fXj/D8EhWG/SLKA7qz4a3QA==}
+    engines: {node: '>= 18'}
+
+  '@intlify/vue-i18n-extensions@8.0.0':
+    resolution: {integrity: sha512-w0+70CvTmuqbskWfzeYhn0IXxllr6mU+IeM2MU0M+j9OW64jkrvqY+pYFWrUnIIC9bEdij3NICruicwd5EgUuQ==}
+    engines: {node: '>= 18'}
+    peerDependencies:
+      '@intlify/shared': ^9.0.0 || ^10.0.0 || ^11.0.0
+      '@vue/compiler-dom': ^3.0.0
+      vue: ^3.0.0
+      vue-i18n: ^9.0.0 || ^10.0.0 || ^11.0.0
+    peerDependenciesMeta:
+      '@intlify/shared':
+        optional: true
+      '@vue/compiler-dom':
+        optional: true
+      vue:
+        optional: true
+      vue-i18n:
+        optional: true
+
   '@ioredis/commands@1.2.0':
     resolution: {integrity: sha512-Sx1pU8EM64o2BrqNpEO1CNLtKQwyhuXuqyfH7oGKCk+1a33d2r5saW8zNwm3j6BTExtjrv2BxTgzzkMwts6vGg==}
 
@@ -1744,6 +1995,9 @@ packages:
     resolution: {integrity: sha512-imAbBGkb+ebQyxKgzv5Hu2nmROxoDOXHh80evxdoXNOrvAnVx7zimzc1Oo5h9RlfV4vPXaE2iM5pOFbvOCClWA==}
     engines: {node: '>=6.0.0'}
 
+  '@jridgewell/remapping@2.3.5':
+    resolution: {integrity: sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==}
+
   '@jridgewell/resolve-uri@3.1.2':
     resolution: {integrity: sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==}
     engines: {node: '>=6.0.0'}
@@ -1757,6 +2011,9 @@ packages:
 
   '@jridgewell/sourcemap-codec@1.5.0':
     resolution: {integrity: sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==}
+
+  '@jridgewell/sourcemap-codec@1.5.5':
+    resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
 
   '@jridgewell/trace-mapping@0.3.25':
     resolution: {integrity: sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==}
@@ -1784,6 +2041,11 @@ packages:
     resolution: {integrity: sha512-llMXd39jtP0HpQLVI37Bf1m2ADlEb35GYSh1SDSLsBhR+5iCxiNGlT31yqbNtVHygHAtMy6dWFERpU2JgufhPg==}
     engines: {node: '>=18'}
     hasBin: true
+
+  '@miyaneee/rollup-plugin-json5@1.2.0':
+    resolution: {integrity: sha512-JjTIaXZp9WzhUHpElrqPnl1AzBi/rvRs065F71+aTmlqvTMVkdbjZ8vfFl4nRlgJy+TPBw69ZK4pwFdmOAt4aA==}
+    peerDependencies:
+      rollup: ^1.20.0 || ^2.0.0 || ^3.0.0 || ^4.0.0
 
   '@napi-rs/wasm-runtime@0.2.9':
     resolution: {integrity: sha512-OKRBiajrrxB9ATokgEQoG87Z25c67pCpYcCwmXYX8PBftC9pBfN18gnm/fh1wurSLEKIAt+QRFLFCQISrb66Jg==}
@@ -1914,6 +2176,10 @@ packages:
     resolution: {integrity: sha512-VG3NlK51jzNNZ9+VIVMwN2YgDddkCkdZRJv0KMs63Z81UQo1FfEwzapqUiV23SWkyyfNSD/1XGarYPOl30J39g==}
     engines: {node: '>=18.12.0'}
 
+  '@nuxt/kit@3.21.6':
+    resolution: {integrity: sha512-5VOwxUcoM/z6w4c75hQrikHpY+TzjTLZQ+QnuO7KajyGx0IJBLVy1lw25oy79leF+GgyjJJO1cHfUfWeuEDCzA==}
+    engines: {node: '>=18.12.0'}
+
   '@nuxt/kit@4.2.2':
     resolution: {integrity: sha512-ZAgYBrPz/yhVgDznBNdQj2vhmOp31haJbO0I0iah/P9atw+OHH7NJLUZ3PK+LOz/0fblKTN1XJVSi8YQ1TQ0KA==}
     engines: {node: '>=18.12.0'}
@@ -1968,8 +2234,18 @@ packages:
   '@nuxtjs/color-mode@3.5.2':
     resolution: {integrity: sha512-cC6RfgZh3guHBMLLjrBB2Uti5eUoGM9KyauOaYS9ETmxNWBMTvpgjvSiSJp1OFljIXPIqVTJ3xtJpSNZiO3ZaA==}
 
+  '@nuxtjs/i18n@9.5.6':
+    resolution: {integrity: sha512-PhrQtJT6Di9uoslL5BTrBFqntFlfCaUKlO3T9ORJwmWFdowPqQeFjQ9OjVbKA6TNWr3kQhDqLbIcGlhbuG1USQ==}
+    engines: {node: '>=18.12.0'}
+
   '@oxc-parser/binding-darwin-arm64@0.67.0':
     resolution: {integrity: sha512-AWLaNH7emKLCpFzHjcYr0wqE8HRpK/5vDtIAUz0BEZKsYxM/Nd8UpgRg2ZlNlEiPDMgAhpRLBHqjf9Xiv/IMhw==}
+    engines: {node: '>=14.0.0'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@oxc-parser/binding-darwin-arm64@0.70.0':
+    resolution: {integrity: sha512-pIi7L9PnsBctS/ruW6JQVSYRJkh76PblBN46uQxpBfVsM57c1s4HGZlmGysQWbdmQTFDZW+SmH3u0JpmDLF0+A==}
     engines: {node: '>=14.0.0'}
     cpu: [arm64]
     os: [darwin]
@@ -1980,8 +2256,32 @@ packages:
     cpu: [x64]
     os: [darwin]
 
+  '@oxc-parser/binding-darwin-x64@0.70.0':
+    resolution: {integrity: sha512-EbKqtOHzZR56ZFC5HHg6XrYneFAJmpLC1Z6FSgbI061Ley1atAViQg7S6Agm9wAcPpns+BeFJqXEBx/y3MKa2w==}
+    engines: {node: '>=14.0.0'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@oxc-parser/binding-freebsd-x64@0.70.0':
+    resolution: {integrity: sha512-MVUaOMEUVE8q3nsWtEo589h++V5wAdqTbCRa9WY4Yuyxska4xcuJQk/kDNCx+n92saS7Luk+b20O9+VCI03c+A==}
+    engines: {node: '>=14.0.0'}
+    cpu: [x64]
+    os: [freebsd]
+
   '@oxc-parser/binding-linux-arm-gnueabihf@0.67.0':
     resolution: {integrity: sha512-Dry9zRk/LOvPvb/GDNkgtQZ2cJKBIc6alQOwjvpji/OdJFjqawTPJoHB0F7nd6NfRYle0tVXCFYHtGUxv2WNxQ==}
+    engines: {node: '>=14.0.0'}
+    cpu: [arm]
+    os: [linux]
+
+  '@oxc-parser/binding-linux-arm-gnueabihf@0.70.0':
+    resolution: {integrity: sha512-8N4JTYTgKiRHlMUDAdzKs6iEC57a8ex408VgKoLD/Fl+Un79qOti3S9sotdnWSdH/BsDQeO5NW+PKaqFBTw+hA==}
+    engines: {node: '>=14.0.0'}
+    cpu: [arm]
+    os: [linux]
+
+  '@oxc-parser/binding-linux-arm-musleabihf@0.70.0':
+    resolution: {integrity: sha512-Bsu+YvtgWuSfSDJTHMF5APZBOtvddR0GiHyrL0yaXDwaYvAL/E7XcoSK2GdmKTpw+J8nk5IlejEXlQliPo52pQ==}
     engines: {node: '>=14.0.0'}
     cpu: [arm]
     os: [linux]
@@ -1992,14 +2292,44 @@ packages:
     cpu: [arm64]
     os: [linux]
 
+  '@oxc-parser/binding-linux-arm64-gnu@0.70.0':
+    resolution: {integrity: sha512-tDzHWKexJPHR+qSiuAFoZ1v8EgCd4ggBNbjJHkcIHsoYKnsKaT1+uE9xfW9UhI1mhv2lo1JJ9n9og2yDTGxSeA==}
+    engines: {node: '>=14.0.0'}
+    cpu: [arm64]
+    os: [linux]
+
   '@oxc-parser/binding-linux-arm64-musl@0.67.0':
     resolution: {integrity: sha512-zBMJOkxgcR7Fgmx6hFJQycgWCl9fhS/oW5n1Qix+cbKFe2HfgtOhI+pESEqHc642WX/93BJ1m4OMmZJl35VYgg==}
     engines: {node: '>=14.0.0'}
     cpu: [arm64]
     os: [linux]
 
+  '@oxc-parser/binding-linux-arm64-musl@0.70.0':
+    resolution: {integrity: sha512-BJ+N25UWmHU624558ojSTnht3uFL00jV1c8qk1hnKf4cl6+ovFcoktRWAWSBlgLEP8tLlu8qgIhz875tMj2PkQ==}
+    engines: {node: '>=14.0.0'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@oxc-parser/binding-linux-riscv64-gnu@0.70.0':
+    resolution: {integrity: sha512-nxu22nVuPA2xy1cxvBC0D5mVl0myqStOw3XBkVkDViNL01iPyuEFJd5VsM0GqsgrXvF95H/jrbMd+XWnto924g==}
+    engines: {node: '>=14.0.0'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@oxc-parser/binding-linux-s390x-gnu@0.70.0':
+    resolution: {integrity: sha512-AQ6Xj97lYRxHZl94cZIHJxT5M1qkeEi+vQe+e7M2lAtjcURl8cwhZmWKSv4rt4BQRVfO3ys0bY8AgIh4eFJiqw==}
+    engines: {node: '>=14.0.0'}
+    cpu: [s390x]
+    os: [linux]
+
   '@oxc-parser/binding-linux-x64-gnu@0.67.0':
     resolution: {integrity: sha512-/zHUMrL24fGMTEr1iHE63f8NYa2IvxfIeNo24H1ofxhtr0A2KmcgOCcEUIypFjMxD5EY5kpQ2t0Nf42o+d4LOA==}
+    engines: {node: '>=14.0.0'}
+    cpu: [x64]
+    os: [linux]
+
+  '@oxc-parser/binding-linux-x64-gnu@0.70.0':
+    resolution: {integrity: sha512-RIxaVsIxtG90CoX6/Okij8itaMrJp4SEJm1pSL0pz3hGo0yur3Il9M1mmGvOpW+avY8uHdwXIvf2qMnnTKZuoQ==}
     engines: {node: '>=14.0.0'}
     cpu: [x64]
     os: [linux]
@@ -2010,13 +2340,30 @@ packages:
     cpu: [x64]
     os: [linux]
 
+  '@oxc-parser/binding-linux-x64-musl@0.70.0':
+    resolution: {integrity: sha512-B3S0G4TlZ+WLdQq4mSQtt2ZW0MAkKWc8dla17tZY86kcXvvCWwACvj7I27Z/nSlb7uJOdRZS9/r6Gw0uAARNVQ==}
+    engines: {node: '>=14.0.0'}
+    cpu: [x64]
+    os: [linux]
+
   '@oxc-parser/binding-wasm32-wasi@0.67.0':
     resolution: {integrity: sha512-jAugJhwJvCSurHEoicL0Gp9k1XVEnrTpQ3l1YBro/jfJ5uKSpfMBPPpNZBW04gumD08RDk32nqcPbk+BezvTaw==}
     engines: {node: '>=14.0.0'}
     cpu: [wasm32]
 
+  '@oxc-parser/binding-wasm32-wasi@0.70.0':
+    resolution: {integrity: sha512-QN8yxH7eHXTqed8Oo7ZUzOWn6hixXa8EVINLy21eLU9isoifSPKMswSmCXHxsM2L5rIIvzoaKfghGOru1mMQbw==}
+    engines: {node: '>=14.0.0'}
+    cpu: [wasm32]
+
   '@oxc-parser/binding-win32-arm64-msvc@0.67.0':
     resolution: {integrity: sha512-JZparqb773ahTQoC3/e6LazRqOLhlyzNhllK73xvz/wixkYueivHxJrdYtFy4ss2VDns4Dg0MZ/zRhkBJy1enA==}
+    engines: {node: '>=14.0.0'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@oxc-parser/binding-win32-arm64-msvc@0.70.0':
+    resolution: {integrity: sha512-6k8/s78g0GQKqrxk4F0wYj32NBF9oSP6089e6BeuIRQ9l+Zh0cuI6unJeLzXNszxmlqq84xmf/tmP3MSDG43Uw==}
     engines: {node: '>=14.0.0'}
     cpu: [arm64]
     os: [win32]
@@ -2027,11 +2374,27 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@oxc-parser/binding-win32-x64-msvc@0.70.0':
+    resolution: {integrity: sha512-nd9o1QtEvupaJZ3Wn7PfsuC00n31NNRQZ5+Mui6Q0ZyDzp+obqPUSbSt7xh9Dy0c5zgtYMk8WY4n/VBJY2VvTQ==}
+    engines: {node: '>=14.0.0'}
+    cpu: [x64]
+    os: [win32]
+
+  '@oxc-parser/wasm@0.60.0':
+    resolution: {integrity: sha512-Dkf9/D87WGBCW3L0+1DtpAfL4SrNsgeRvxwjpKCtbH7Kf6K+pxrT0IridaJfmWKu1Ml+fDvj+7HEyBcfUC/TXQ==}
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
+
   '@oxc-project/types@0.103.0':
     resolution: {integrity: sha512-bkiYX5kaXWwUessFRSoXFkGIQTmc6dLGdxuRTrC+h8PSnIdZyuXHHlLAeTmOue5Br/a0/a7dHH0Gca6eXn9MKg==}
 
+  '@oxc-project/types@0.60.0':
+    resolution: {integrity: sha512-prhfNnb3ATFHOCv7mzKFfwLij5RzoUz6Y1n525ZhCEqfq5wreCXL+DyVoq3ShukPo7q45ZjYIdjFUgjj+WKzng==}
+
   '@oxc-project/types@0.67.0':
     resolution: {integrity: sha512-AI7inoYvnVro7b8S2Z+Fxi295xQvNKLP1CM/xzx5il4R3aiGgnFt9qiXaRo9vIutataX8AjHcaPnOsjdcItU0w==}
+
+  '@oxc-project/types@0.70.0':
+    resolution: {integrity: sha512-ngyLUpUjO3dpqygSRQDx7nMx8+BmXbWOU4oIwTJFV2MVIDG7knIZwgdwXlQWLg3C3oxg1lS7ppMtPKqKFb7wzw==}
 
   '@parcel/watcher-android-arm64@2.5.1':
     resolution: {integrity: sha512-KF8+j9nNbUN8vzOFDpRMsaKBHZ/mcjEjMToVMJOhTozkDonQFFrRcfdLWn6yWKCmJKmdVxSgHiYvTCef4/qcBA==}
@@ -2340,6 +2703,15 @@ packages:
     engines: {node: '>=14.0.0'}
     peerDependencies:
       rollup: ^2.0.0||^3.0.0||^4.0.0
+    peerDependenciesMeta:
+      rollup:
+        optional: true
+
+  '@rollup/plugin-yaml@4.1.2':
+    resolution: {integrity: sha512-RpupciIeZMUqhgFE97ba0s98mOFS7CWzN3EJNhJkqSv9XLlWYtwVdtE6cDw6ASOF/sZVFS7kRJXftaqM2Vakdw==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      rollup: ^1.20.0||^2.0.0||^3.0.0||^4.0.0
     peerDependenciesMeta:
       rollup:
         optional: true
@@ -2880,14 +3252,26 @@ packages:
   '@vue/compiler-core@3.5.13':
     resolution: {integrity: sha512-oOdAkwqUfW1WqpwSYJce06wvt6HljgY3fGeM9NcVA1HaYOij3mZG9Rkysn0OHuyUAGMbEbARIpsG+LPVlBJ5/Q==}
 
+  '@vue/compiler-core@3.5.35':
+    resolution: {integrity: sha512-BUmHaR1J+O+CKZ9uJucdVTEr1LHsdyvv7vG3eNRhK3CczEHeMd/LtsHAuD7PbrxvI2envCY2v7HI1vC1aBRzKw==}
+
   '@vue/compiler-dom@3.5.13':
     resolution: {integrity: sha512-ZOJ46sMOKUjO3e94wPdCzQ6P1Lx/vhp2RSvfaab88Ajexs0AHeV0uasYhi99WPaogmBlRHNRuly8xV75cNTMDA==}
+
+  '@vue/compiler-dom@3.5.35':
+    resolution: {integrity: sha512-k+bprkXxuqhVajgTx5mUHuir7TwQzUKOWR40ng1ncAqQRPnrLngGGgqVEEhOnTMlc8btHYVKmrP8s5Qyg0hvYA==}
 
   '@vue/compiler-sfc@3.5.13':
     resolution: {integrity: sha512-6VdaljMpD82w6c2749Zhf5T9u5uLBWKnVue6XWxprDobftnletJ8+oel7sexFfM3qIxNmVE7LSFGTpv6obNyaQ==}
 
+  '@vue/compiler-sfc@3.5.35':
+    resolution: {integrity: sha512-G5VPMcXTSywXBgtFOZOnHKBxKSrwXUcvY1iaF5/hRcy7t0J6CH/d8ha9F4nzi00Fax1eLV0QHM7v4mQu68jydw==}
+
   '@vue/compiler-ssr@3.5.13':
     resolution: {integrity: sha512-wMH6vrYHxQl/IybKJagqbquvxpWCuVYpoUJfCqFZwa/JY1GdATAQ+TgVtgrwwMZ0D07QhA99rs/EAAWfvG6KpA==}
+
+  '@vue/compiler-ssr@3.5.35':
+    resolution: {integrity: sha512-rGhAeXgdM7/ffTJGXT69rCCdTmjDewnFuUZfBQQHTdcEBeWdT5HCGY60y2ytLJr9/Dsu7IntUi5z/w0h6Rjnzw==}
 
   '@vue/compiler-vue2@2.7.16':
     resolution: {integrity: sha512-qYC3Psj9S/mfu9uVi5WvNZIzq+xnXMhOwbTFKKDD7b1lhpnn71jXSFdTQ+WsIEk0ONCd7VV2IMm7ONl6tbQ86A==}
@@ -2930,6 +3314,9 @@ packages:
 
   '@vue/shared@3.5.13':
     resolution: {integrity: sha512-/hnE/qP5ZoGpol0a5mDi45bOd7t3tjYJBjsgCsivow7D48cJeV5l05RD82lPqi7gRiphZM37rnhW1l6ZoCNNnQ==}
+
+  '@vue/shared@3.5.35':
+    resolution: {integrity: sha512-zSbjL7gRXwks2ZQLRGCajBtBXEOXW9Ddhn/HvSdrGkE2dqGnumzW8XtusRrxrE9LvqtiqDXQ+A60Hp6mvdYxfA==}
 
   '@vueuse/core@10.11.1':
     resolution: {integrity: sha512-guoy26JQktXPcz+0n3GukWIy/JDNKti9v6VEMu6kV2sYBsWuGiTU8OWdg+ADfUbHg3/3DlqySDe7JmdHrktiww==}
@@ -3056,6 +3443,11 @@ packages:
 
   acorn@8.15.0:
     resolution: {integrity: sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==}
+    engines: {node: '>=0.4.0'}
+    hasBin: true
+
+  acorn@8.16.0:
+    resolution: {integrity: sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==}
     engines: {node: '>=0.4.0'}
     hasBin: true
 
@@ -3304,6 +3696,14 @@ packages:
       magicast:
         optional: true
 
+  c12@3.3.4:
+    resolution: {integrity: sha512-cM0ApFQSBXuourJejzwv/AuPRvAxordTyParRVcHjjtXirtkzM0uK2L9TTn9s0cXZbG7E55jCivRQzoxYmRAlA==}
+    peerDependencies:
+      magicast: '*'
+    peerDependenciesMeta:
+      magicast:
+        optional: true
+
   cac@6.7.14:
     resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
     engines: {node: '>=8'}
@@ -3470,6 +3870,9 @@ packages:
 
   confbox@0.2.2:
     resolution: {integrity: sha512-1NB+BKqhtNipMsov4xI/NnhCKp9XG9NamYp5PVm9klAT0fsrNPjaFICsCFhNhwZJKNh7zB/3q8qXz0E9oaMNtQ==}
+
+  confbox@0.2.4:
+    resolution: {integrity: sha512-ysOGlgTFbN2/Y6Cg3Iye8YKulHw+R2fNXHrgSmXISQdMnomY6eNDprVdW9R5xBguEqI954+S6709UyiO7B+6OQ==}
 
   consola@3.4.2:
     resolution: {integrity: sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==}
@@ -3705,6 +4108,9 @@ packages:
   defu@6.1.4:
     resolution: {integrity: sha512-mEQCMmwJu317oSz8CwdIOdwf3xMif1ttiM8LTufzc3g6kR+9Pe236twL8j3IYT1F7GfRgGcW6MWxzZjLIkuHIg==}
 
+  defu@6.1.7:
+    resolution: {integrity: sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ==}
+
   delegates@1.0.0:
     resolution: {integrity: sha512-bd2L678uiWATM6m5Z1VzNCErI3jiGzt6HGY8OVICs40JQq/HALfbyNJmp0UDakEY4pMMaN0Ly5om/B1VI/+xfQ==}
 
@@ -3802,6 +4208,10 @@ packages:
 
   dotenv@17.2.3:
     resolution: {integrity: sha512-JVUnt+DUIzu87TABbhPmNfVdBDt18BLOWjMUFJMSi/Qqg7NTYtabbvSNJGOJ7afbRuv9D/lngizHtP7QyLQ+9w==}
+    engines: {node: '>=12'}
+
+  dotenv@17.4.2:
+    resolution: {integrity: sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==}
     engines: {node: '>=12'}
 
   dts-resolver@2.1.3:
@@ -3906,6 +4316,10 @@ packages:
     resolution: {integrity: sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==}
     engines: {node: '>=0.12'}
 
+  entities@7.0.1:
+    resolution: {integrity: sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==}
+    engines: {node: '>=0.12'}
+
   env-paths@3.0.0:
     resolution: {integrity: sha512-dtJUTepzMW3Lm/NPxRf3wP4642UWhjL2sQxc+ym2YMj1m/H2zDNQOlezafzkHwn6sMstjHTwG6iQQsctDW/b1A==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
@@ -3946,6 +4360,11 @@ packages:
   esbuild@0.19.11:
     resolution: {integrity: sha512-HJ96Hev2hX/6i5cDVwcqiJBBtuo9+FeIJOtZ9W1kA5M6AMJRHUZlpYZ1/SbEwtO0ioNAW8rUooVpC/WehY2SfA==}
     engines: {node: '>=12'}
+    hasBin: true
+
+  esbuild@0.25.12:
+    resolution: {integrity: sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==}
+    engines: {node: '>=18'}
     hasBin: true
 
   esbuild@0.25.2:
@@ -4065,6 +4484,10 @@ packages:
   espree@10.3.0:
     resolution: {integrity: sha512-0QYC8b24HWY8zjRnDTL6RiHfDbAWn63qb4LMj1Z4b076A4une81+z03Kg7l7mn/48PUTqoLptSXez8oknU8Clg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  espree@9.6.1:
+    resolution: {integrity: sha512-oruZaFkjorTpF32kDSI5/75ViwGeZginGGy2NoOSg3Q9bnwlnmDm4HLnkl0RE3n+njDXR037aY1+x58Z/zFdwQ==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
 
   esprima@4.0.1:
     resolution: {integrity: sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==}
@@ -4365,6 +4788,10 @@ packages:
 
   giget@2.0.0:
     resolution: {integrity: sha512-L5bGsVkxJbJgdnwyuheIunkGatUF/zssUoxxjACCseZYAVbaqdh9Tsmmlkl8vYan09H7sbvKt4pS8GqKLBrEzA==}
+    hasBin: true
+
+  giget@3.2.0:
+    resolution: {integrity: sha512-GvHTWcykIR/fP8cj8dMpuMMkvaeJfPvYnhq0oW+chSeIr+ldX21ifU2Ms6KBoyKZQZmVaUAAhQ2EZ68KJF8a7A==}
     hasBin: true
 
   git-up@8.1.1:
@@ -4839,6 +5266,10 @@ packages:
     resolution: {integrity: sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==}
     hasBin: true
 
+  jiti@2.7.0:
+    resolution: {integrity: sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==}
+    hasBin: true
+
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
@@ -4886,6 +5317,10 @@ packages:
     engines: {node: '>=6'}
     hasBin: true
 
+  jsonc-eslint-parser@2.4.2:
+    resolution: {integrity: sha512-1e4qoRgnn448pRuMvKGsFFymUCquZV0mpGgOyIKNgD3JVDTsVJyRBGH/Fm0tBb8WsWGgmB1mDe6/yJMQM37DUA==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+
   jsonfile@6.1.0:
     resolution: {integrity: sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==}
 
@@ -4918,6 +5353,9 @@ packages:
 
   knitwork@1.2.0:
     resolution: {integrity: sha512-xYSH7AvuQ6nXkq42x0v5S8/Iry+cfulBz/DJQzhIyESdLD7425jXsPy4vn5cCXU+HhRN2kVw51Vd1K6/By4BQg==}
+
+  knitwork@1.3.0:
+    resolution: {integrity: sha512-4LqMNoONzR43B1W0ek0fhXMsDNW/zxa1NdFAVMY+k28pgZLovR4G3PB5MrpTxCy1QaZCqNoiaKPr5w5qZHfSNw==}
 
   kolorist@1.8.0:
     resolution: {integrity: sha512-Y+60/zizpJ3HRH8DCss+q95yr6145JXZo46OTpFvDZWLfRCE4qChOyk1b26nMaNpfHHgxagk9dXT5OP0Tfe+dQ==}
@@ -5093,6 +5531,9 @@ packages:
   magic-string@0.30.17:
     resolution: {integrity: sha512-sNPKHvyjVf7gyjwS4xGTaW/mCnF8wnjtifKBEhxfZ7E/S8tQ0rssrwGNn6q8JH/ohItJfSQp9mBtQYuTlH5QnA==}
 
+  magic-string@0.30.21:
+    resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
   magicast@0.3.5:
     resolution: {integrity: sha512-L0WhttDl+2BOsybvEOLK7fW3UA0OQ0IQ2d6Zl2x/a6vVRs3bAY0ECOSHHeL5jD+SbOpOCUEi0y1DgHEn9Qn1AQ==}
 
@@ -5224,6 +5665,9 @@ packages:
   mlly@1.8.0:
     resolution: {integrity: sha512-l8D9ODSRWLe2KHJSifWGwBqpTZXIXTeo8mlKjY+E2HAakaTeNpqAyBZ8GSqLzHgw4XmHmC8whvpjJNMbFZN7/g==}
 
+  mlly@1.8.2:
+    resolution: {integrity: sha512-d+ObxMQFmbt10sretNDytwt85VrbkhhUA/JBGm1MPaWJ65Cl4wOgLaB1NYvJSZ0Ef03MMEU/0xpPMXUIQ29UfA==}
+
   mocked-exports@0.1.1:
     resolution: {integrity: sha512-aF7yRQr/Q0O2/4pIXm6PZ5G+jAd7QS4Yu8m+WEeEHGnbo+7mE36CbLSDQiXYV8bVL3NfmdeqPJct0tUlnjVSnA==}
 
@@ -5248,6 +5692,11 @@ packages:
 
   nanoid@3.3.11:
     resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
+    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
+
+  nanoid@3.3.12:
+    resolution: {integrity: sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -5456,6 +5905,10 @@ packages:
     resolution: {integrity: sha512-07arJoEJQopwEQ3gDu220l9J7i4XIyOWUGhfRalOX6gKEEYZIaqts5zJvFNtwNSjCc2yHMYscAdHNAB8nRazjA==}
     engines: {node: '>=14.0.0'}
 
+  oxc-parser@0.70.0:
+    resolution: {integrity: sha512-YbqTuQDDIYwQF/li0VFK5uTbmHV4jWFeQQONkPdf77vz+JMiq7SusmcSVZ4hBrGM+3WyLdKH5S7spnvz4XVVzQ==}
+    engines: {node: '>=14.0.0'}
+
   p-event@5.0.1:
     resolution: {integrity: sha512-dd589iCQ7m1L0bmC5NLlVYfy3TbBEsMUfWx9PyAgPeIcFZ/E2yaTZ4Rz4MiBmmJShviiftHVXOqfnfzJ6kyMrQ==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
@@ -5589,6 +6042,9 @@ packages:
   perfect-debounce@2.0.0:
     resolution: {integrity: sha512-fkEH/OBiKrqqI/yIgjR92lMfs2K8105zt/VT6+7eTjNwisrsh47CeIED9z58zI7DfKdH3uHAn25ziRZn3kgAow==}
 
+  perfect-debounce@2.1.0:
+    resolution: {integrity: sha512-LjgdTytVFXeUgtHZr9WYViYSM/g8MkcTPYDlPa3cDqMirHjKiSZPYd6DoL7pK8AJQr+uWkQvCjHNdiMqsrJs+g==}
+
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
 
@@ -5604,6 +6060,10 @@ packages:
     resolution: {integrity: sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==}
     engines: {node: '>=12'}
 
+  picomatch@4.0.4:
+    resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
+    engines: {node: '>=12'}
+
   pkg-types@1.3.1:
     resolution: {integrity: sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==}
 
@@ -5612,6 +6072,9 @@ packages:
 
   pkg-types@2.3.0:
     resolution: {integrity: sha512-SIqCzDRg0s9npO5XQ3tNZioRY1uK06lA41ynBC1YmFTmnY6FjUjVt6s4LoADmwoig1qqD0oK8h1p/8mlMx8Oig==}
+
+  pkg-types@2.3.1:
+    resolution: {integrity: sha512-y+ichcgc2LrADuhLNAx8DFjVfgz91pRxfZdI3UDhxHvcVEZsenLO+7XaU5vOp0u/7V/wZ+plyuQxtrDlZJ+yeg==}
 
   pluralize@8.0.0:
     resolution: {integrity: sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA==}
@@ -5800,6 +6263,10 @@ packages:
     peerDependencies:
       postcss: ^8.2.9
 
+  postcss@8.5.15:
+    resolution: {integrity: sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==}
+    engines: {node: ^10 || ^12 || >=14}
+
   postcss@8.5.3:
     resolution: {integrity: sha512-dle9A3yYxlBSrt8Fu+IpjGT8SY8hN0mlaA6GY8t0P5PjIOZemULz/E2Bnm/2dcUOena75OTNkHI76uZBNUUq3A==}
     engines: {node: ^10 || ^12 || >=14}
@@ -5886,6 +6353,9 @@ packages:
 
   rc9@2.1.2:
     resolution: {integrity: sha512-btXCnMmRIBINM2LDZoEmOogIZU7Qe7zn4BpomSKZ/ykbLObuBdvG+mFq11DL6fjH1DRwHhrlgtYWG96bJiC7Cg==}
+
+  rc9@3.0.1:
+    resolution: {integrity: sha512-gMDyleLWVE+i6Sgtc0QbbY6pEKqYs97NGi6isHQPqYlLemPoO8dxQ3uGi0f4NiP98c+jMW6cG1Kx9dDwfvqARQ==}
 
   read-package-up@11.0.0:
     resolution: {integrity: sha512-MbgfoNPANMdb4oRBNg5eqLbB2t2r+o5Ua1pNt8BqGp4I0FJZhuVSOj3PaBPni4azWuSzEdNn2evevzVmEk1ohQ==}
@@ -6119,6 +6589,11 @@ packages:
 
   semver@7.7.3:
     resolution: {integrity: sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==}
+    engines: {node: '>=10'}
+    hasBin: true
+
+  semver@7.8.1:
+    resolution: {integrity: sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg==}
     engines: {node: '>=10'}
     hasBin: true
 
@@ -6470,6 +6945,10 @@ packages:
     resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
     engines: {node: '>=12.0.0'}
 
+  tinyglobby@0.2.17:
+    resolution: {integrity: sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==}
+    engines: {node: '>=12.0.0'}
+
   tmp-promise@3.0.3:
     resolution: {integrity: sha512-RwM7MoPojPxsOBYnyd2hy0bxtIlVrihNs9pj5SUvY8Zz1sQcQG2tG1hSr8PDxfgEB8RNKDhqbIlroIarSNDNsQ==}
 
@@ -6490,6 +6969,10 @@ packages:
 
   toml@3.0.0:
     resolution: {integrity: sha512-y/mWCZinnvxjTKYhJ+pYxwD0mRLVvOtdS2Awbgxln6iEnt4rk0yBxeSBHkGJcPucRiG0e55mwWp+g/05rsrd6w==}
+
+  tosource@2.0.0-alpha.3:
+    resolution: {integrity: sha512-KAB2lrSS48y91MzFPFuDg4hLbvDiyTjOVgaK7Erw+5AmZXNq4sFRVn8r6yxSLuNs15PaokrDRpS61ERY9uZOug==}
+    engines: {node: '>=10'}
 
   totalist@3.0.1:
     resolution: {integrity: sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ==}
@@ -6591,6 +7074,9 @@ packages:
   ufo@1.6.1:
     resolution: {integrity: sha512-9a4/uxlTWJ4+a5i0ooc1rU7C7YOw3wT+UGqdeNNHWnOF9qcMBgLRS+4IYUqbczewFx4mLEig6gawh7X6mFlEkA==}
 
+  ufo@1.6.4:
+    resolution: {integrity: sha512-JFNbkD1Svwe0KvGi8GOeLcP4kAWQ609twvCdcHxq1oSL8svv39ZuSvajcD8B+5D0eL4+s1Is2D/O6KN3qcTeRA==}
+
   ultrahtml@1.6.0:
     resolution: {integrity: sha512-R9fBn90VTJrqqLDwyMph+HGne8eqY1iPfYhPzZrvKpIfwkWZbcYlfpsb8B9dTvBfpy1/hqAD7Wi8EKfP9e8zdw==}
 
@@ -6609,6 +7095,9 @@ packages:
 
   unctx@2.4.1:
     resolution: {integrity: sha512-AbaYw0Nm4mK4qjhns67C+kgxR2YWiwlDBPzxrN8h8C6VtAdCgditAY5Dezu3IJy4XVqAnbrXt9oQJvsn3fyozg==}
+
+  unctx@2.5.0:
+    resolution: {integrity: sha512-p+Rz9x0R7X+CYDkT+Xg8/GhpcShTlU8n+cf9OtOEf7zEQsNcCZO1dPKNRDqvUTaq+P32PMMkxWHwfrxkqfqAYg==}
 
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
@@ -6716,6 +7205,10 @@ packages:
   unplugin@1.16.1:
     resolution: {integrity: sha512-4/u/j4FrCKdi17jaxuJA0jClGxB1AvU2hw/IuayPc4ay1XGaJs/rbb4v5WKwAjNifjmXK9PIFyuPiaK8azyR9w==}
     engines: {node: '>=14.0.0'}
+
+  unplugin@2.3.11:
+    resolution: {integrity: sha512-5uKD0nqiYVzlmCRs01Fhs2BdkEgBS3SAVP6ndrBsuK42iC2+JHyxM05Rm9G8+5mkmRtzMZGY8Ct5+mliZxU/Ww==}
+    engines: {node: '>=18.12.0'}
 
   unplugin@2.3.2:
     resolution: {integrity: sha512-3n7YA46rROb3zSj8fFxtxC/PqoyvYQ0llwz9wtUPUutr9ig09C8gGo5CWCwHrUzlqC1LLR43kxp5vEIyH1ac1w==}
@@ -7047,6 +7540,13 @@ packages:
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0
 
+  vue-i18n@10.0.8:
+    resolution: {integrity: sha512-mIjy4utxMz9lMMo6G9vYePv7gUFt4ztOMhY9/4czDJxZ26xPeJ49MAGa9wBAE3XuXbYCrtVPmPxNjej7JJJkZQ==}
+    engines: {node: '>= 16'}
+    deprecated: v9 and v10 no longer supported. please migrate to v11. about maintenance status, see https://vue-i18n.intlify.dev/guide/maintenance.html
+    peerDependencies:
+      vue: ^3.0.0
+
   vue-router@4.5.1:
     resolution: {integrity: sha512-ogAF3P97NPm8fJsE4by9dwSYtDwXIY1nFY9T6DyQnGHd1E2Da94w9JIolpe42LJGIl0DwOHBi8TcRPlPGwbTtw==}
     peerDependencies:
@@ -7267,9 +7767,18 @@ packages:
     resolution: {integrity: sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==}
     engines: {node: '>=18'}
 
+  yaml-eslint-parser@1.3.2:
+    resolution: {integrity: sha512-odxVsHAkZYYglR30aPYRY4nUGJnoJ2y1ww2HDvZALo0BDETv9kWbi16J52eHs+PWRNmF4ub6nZqfVOeesOvntg==}
+    engines: {node: ^14.17.0 || >=16.0.0}
+
   yaml@2.7.1:
     resolution: {integrity: sha512-10ULxpnOCQXxJvBgxsn9ptjq6uviG/htZKk9veJGhlqn3w/DxQ631zFF+nlQXLwmImeS5amR2dl2U8sg6U9jsQ==}
     engines: {node: '>= 14'}
+    hasBin: true
+
+  yaml@2.9.0:
+    resolution: {integrity: sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==}
+    engines: {node: '>= 14.6'}
     hasBin: true
 
   yargs-parser@21.1.1:
@@ -7491,9 +8000,13 @@ snapshots:
 
   '@babel/helper-string-parser@7.27.1': {}
 
+  '@babel/helper-string-parser@7.29.7': {}
+
   '@babel/helper-validator-identifier@7.27.1': {}
 
   '@babel/helper-validator-identifier@7.28.5': {}
+
+  '@babel/helper-validator-identifier@7.29.7': {}
 
   '@babel/helper-validator-option@7.27.1': {}
 
@@ -7501,7 +8014,7 @@ snapshots:
     dependencies:
       '@babel/template': 7.27.1
       '@babel/traverse': 7.27.1
-      '@babel/types': 7.28.5
+      '@babel/types': 7.29.7
     transitivePeerDependencies:
       - supports-color
 
@@ -7517,6 +8030,10 @@ snapshots:
   '@babel/parser@7.28.5':
     dependencies:
       '@babel/types': 7.28.5
+
+  '@babel/parser@7.29.7':
+    dependencies:
+      '@babel/types': 7.29.7
 
   '@babel/plugin-bugfix-firefox-class-in-computed-class-key@7.27.1(@babel/core@7.27.1)':
     dependencies:
@@ -7745,7 +8262,7 @@ snapshots:
       '@babel/core': 7.27.1
       '@babel/helper-module-transforms': 7.27.1(@babel/core@7.27.1)
       '@babel/helper-plugin-utils': 7.27.1
-      '@babel/helper-validator-identifier': 7.28.5
+      '@babel/helper-validator-identifier': 7.29.7
       '@babel/traverse': 7.27.1
     transitivePeerDependencies:
       - supports-color
@@ -7991,7 +8508,7 @@ snapshots:
     dependencies:
       '@babel/core': 7.27.1
       '@babel/helper-plugin-utils': 7.27.1
-      '@babel/types': 7.28.5
+      '@babel/types': 7.29.7
       esutils: 2.0.3
 
   '@babel/runtime@7.27.1': {}
@@ -8028,6 +8545,11 @@ snapshots:
     dependencies:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.28.5
+
+  '@babel/types@7.29.7':
+    dependencies:
+      '@babel/helper-string-parser': 7.29.7
+      '@babel/helper-validator-identifier': 7.29.7
 
   '@canvas/image-data@1.0.0': {}
 
@@ -8132,6 +8654,9 @@ snapshots:
   '@esbuild/aix-ppc64@0.19.11':
     optional: true
 
+  '@esbuild/aix-ppc64@0.25.12':
+    optional: true
+
   '@esbuild/aix-ppc64@0.25.2':
     optional: true
 
@@ -8139,6 +8664,9 @@ snapshots:
     optional: true
 
   '@esbuild/android-arm64@0.19.11':
+    optional: true
+
+  '@esbuild/android-arm64@0.25.12':
     optional: true
 
   '@esbuild/android-arm64@0.25.2':
@@ -8150,6 +8678,9 @@ snapshots:
   '@esbuild/android-arm@0.19.11':
     optional: true
 
+  '@esbuild/android-arm@0.25.12':
+    optional: true
+
   '@esbuild/android-arm@0.25.2':
     optional: true
 
@@ -8157,6 +8688,9 @@ snapshots:
     optional: true
 
   '@esbuild/android-x64@0.19.11':
+    optional: true
+
+  '@esbuild/android-x64@0.25.12':
     optional: true
 
   '@esbuild/android-x64@0.25.2':
@@ -8168,6 +8702,9 @@ snapshots:
   '@esbuild/darwin-arm64@0.19.11':
     optional: true
 
+  '@esbuild/darwin-arm64@0.25.12':
+    optional: true
+
   '@esbuild/darwin-arm64@0.25.2':
     optional: true
 
@@ -8175,6 +8712,9 @@ snapshots:
     optional: true
 
   '@esbuild/darwin-x64@0.19.11':
+    optional: true
+
+  '@esbuild/darwin-x64@0.25.12':
     optional: true
 
   '@esbuild/darwin-x64@0.25.2':
@@ -8186,6 +8726,9 @@ snapshots:
   '@esbuild/freebsd-arm64@0.19.11':
     optional: true
 
+  '@esbuild/freebsd-arm64@0.25.12':
+    optional: true
+
   '@esbuild/freebsd-arm64@0.25.2':
     optional: true
 
@@ -8193,6 +8736,9 @@ snapshots:
     optional: true
 
   '@esbuild/freebsd-x64@0.19.11':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.25.12':
     optional: true
 
   '@esbuild/freebsd-x64@0.25.2':
@@ -8204,6 +8750,9 @@ snapshots:
   '@esbuild/linux-arm64@0.19.11':
     optional: true
 
+  '@esbuild/linux-arm64@0.25.12':
+    optional: true
+
   '@esbuild/linux-arm64@0.25.2':
     optional: true
 
@@ -8211,6 +8760,9 @@ snapshots:
     optional: true
 
   '@esbuild/linux-arm@0.19.11':
+    optional: true
+
+  '@esbuild/linux-arm@0.25.12':
     optional: true
 
   '@esbuild/linux-arm@0.25.2':
@@ -8222,6 +8774,9 @@ snapshots:
   '@esbuild/linux-ia32@0.19.11':
     optional: true
 
+  '@esbuild/linux-ia32@0.25.12':
+    optional: true
+
   '@esbuild/linux-ia32@0.25.2':
     optional: true
 
@@ -8229,6 +8784,9 @@ snapshots:
     optional: true
 
   '@esbuild/linux-loong64@0.19.11':
+    optional: true
+
+  '@esbuild/linux-loong64@0.25.12':
     optional: true
 
   '@esbuild/linux-loong64@0.25.2':
@@ -8240,6 +8798,9 @@ snapshots:
   '@esbuild/linux-mips64el@0.19.11':
     optional: true
 
+  '@esbuild/linux-mips64el@0.25.12':
+    optional: true
+
   '@esbuild/linux-mips64el@0.25.2':
     optional: true
 
@@ -8247,6 +8808,9 @@ snapshots:
     optional: true
 
   '@esbuild/linux-ppc64@0.19.11':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.25.12':
     optional: true
 
   '@esbuild/linux-ppc64@0.25.2':
@@ -8258,6 +8822,9 @@ snapshots:
   '@esbuild/linux-riscv64@0.19.11':
     optional: true
 
+  '@esbuild/linux-riscv64@0.25.12':
+    optional: true
+
   '@esbuild/linux-riscv64@0.25.2':
     optional: true
 
@@ -8265,6 +8832,9 @@ snapshots:
     optional: true
 
   '@esbuild/linux-s390x@0.19.11':
+    optional: true
+
+  '@esbuild/linux-s390x@0.25.12':
     optional: true
 
   '@esbuild/linux-s390x@0.25.2':
@@ -8276,10 +8846,16 @@ snapshots:
   '@esbuild/linux-x64@0.19.11':
     optional: true
 
+  '@esbuild/linux-x64@0.25.12':
+    optional: true
+
   '@esbuild/linux-x64@0.25.2':
     optional: true
 
   '@esbuild/linux-x64@0.25.3':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.25.12':
     optional: true
 
   '@esbuild/netbsd-arm64@0.25.2':
@@ -8291,10 +8867,16 @@ snapshots:
   '@esbuild/netbsd-x64@0.19.11':
     optional: true
 
+  '@esbuild/netbsd-x64@0.25.12':
+    optional: true
+
   '@esbuild/netbsd-x64@0.25.2':
     optional: true
 
   '@esbuild/netbsd-x64@0.25.3':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.25.12':
     optional: true
 
   '@esbuild/openbsd-arm64@0.25.2':
@@ -8306,13 +8888,22 @@ snapshots:
   '@esbuild/openbsd-x64@0.19.11':
     optional: true
 
+  '@esbuild/openbsd-x64@0.25.12':
+    optional: true
+
   '@esbuild/openbsd-x64@0.25.2':
     optional: true
 
   '@esbuild/openbsd-x64@0.25.3':
     optional: true
 
+  '@esbuild/openharmony-arm64@0.25.12':
+    optional: true
+
   '@esbuild/sunos-x64@0.19.11':
+    optional: true
+
+  '@esbuild/sunos-x64@0.25.12':
     optional: true
 
   '@esbuild/sunos-x64@0.25.2':
@@ -8324,6 +8915,9 @@ snapshots:
   '@esbuild/win32-arm64@0.19.11':
     optional: true
 
+  '@esbuild/win32-arm64@0.25.12':
+    optional: true
+
   '@esbuild/win32-arm64@0.25.2':
     optional: true
 
@@ -8333,6 +8927,9 @@ snapshots:
   '@esbuild/win32-ia32@0.19.11':
     optional: true
 
+  '@esbuild/win32-ia32@0.25.12':
+    optional: true
+
   '@esbuild/win32-ia32@0.25.2':
     optional: true
 
@@ -8340,6 +8937,9 @@ snapshots:
     optional: true
 
   '@esbuild/win32-x64@0.19.11':
+    optional: true
+
+  '@esbuild/win32-x64@0.25.12':
     optional: true
 
   '@esbuild/win32-x64@0.25.2':
@@ -8993,6 +9593,87 @@ snapshots:
     dependencies:
       '@swc/helpers': 0.5.17
 
+  '@intlify/bundle-utils@10.0.1(vue-i18n@10.0.8(vue@3.5.13(typescript@5.8.3)))':
+    dependencies:
+      '@intlify/message-compiler': 11.4.4
+      '@intlify/shared': 11.4.4
+      acorn: 8.16.0
+      escodegen: 2.1.0
+      estree-walker: 2.0.2
+      jsonc-eslint-parser: 2.4.2
+      mlly: 1.8.2
+      source-map-js: 1.2.1
+      yaml-eslint-parser: 1.3.2
+    optionalDependencies:
+      vue-i18n: 10.0.8(vue@3.5.13(typescript@5.8.3))
+
+  '@intlify/core-base@10.0.8':
+    dependencies:
+      '@intlify/message-compiler': 10.0.8
+      '@intlify/shared': 10.0.8
+
+  '@intlify/core@10.0.8':
+    dependencies:
+      '@intlify/core-base': 10.0.8
+      '@intlify/shared': 10.0.8
+
+  '@intlify/h3@0.6.1':
+    dependencies:
+      '@intlify/core': 10.0.8
+      '@intlify/utils': 0.13.0
+
+  '@intlify/message-compiler@10.0.8':
+    dependencies:
+      '@intlify/shared': 10.0.8
+      source-map-js: 1.2.1
+
+  '@intlify/message-compiler@11.4.4':
+    dependencies:
+      '@intlify/shared': 11.4.4
+      source-map-js: 1.2.1
+
+  '@intlify/shared@10.0.8': {}
+
+  '@intlify/shared@11.4.4': {}
+
+  '@intlify/unplugin-vue-i18n@6.0.8(@vue/compiler-dom@3.5.35)(eslint@9.25.1(jiti@2.6.1))(rollup@4.40.1)(typescript@5.8.3)(vue-i18n@10.0.8(vue@3.5.13(typescript@5.8.3)))(vue@3.5.13(typescript@5.8.3))':
+    dependencies:
+      '@eslint-community/eslint-utils': 4.6.1(eslint@9.25.1(jiti@2.6.1))
+      '@intlify/bundle-utils': 10.0.1(vue-i18n@10.0.8(vue@3.5.13(typescript@5.8.3)))
+      '@intlify/shared': 11.4.4
+      '@intlify/vue-i18n-extensions': 8.0.0(@intlify/shared@11.4.4)(@vue/compiler-dom@3.5.35)(vue-i18n@10.0.8(vue@3.5.13(typescript@5.8.3)))(vue@3.5.13(typescript@5.8.3))
+      '@rollup/pluginutils': 5.1.4(rollup@4.40.1)
+      '@typescript-eslint/scope-manager': 8.31.1
+      '@typescript-eslint/typescript-estree': 8.31.1(typescript@5.8.3)
+      debug: 4.4.0
+      fast-glob: 3.3.3
+      js-yaml: 4.1.0
+      json5: 2.2.3
+      pathe: 1.1.2
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
+      unplugin: 1.16.1
+      vue: 3.5.13(typescript@5.8.3)
+    optionalDependencies:
+      vue-i18n: 10.0.8(vue@3.5.13(typescript@5.8.3))
+    transitivePeerDependencies:
+      - '@vue/compiler-dom'
+      - eslint
+      - rollup
+      - supports-color
+      - typescript
+
+  '@intlify/utils@0.13.0': {}
+
+  '@intlify/vue-i18n-extensions@8.0.0(@intlify/shared@11.4.4)(@vue/compiler-dom@3.5.35)(vue-i18n@10.0.8(vue@3.5.13(typescript@5.8.3)))(vue@3.5.13(typescript@5.8.3))':
+    dependencies:
+      '@babel/parser': 7.29.7
+    optionalDependencies:
+      '@intlify/shared': 11.4.4
+      '@vue/compiler-dom': 3.5.35
+      vue: 3.5.13(typescript@5.8.3)
+      vue-i18n: 10.0.8(vue@3.5.13(typescript@5.8.3))
+
   '@ioredis/commands@1.2.0': {}
 
   '@isaacs/cliui@8.0.2':
@@ -9019,6 +9700,11 @@ snapshots:
       '@jridgewell/sourcemap-codec': 1.5.0
       '@jridgewell/trace-mapping': 0.3.25
 
+  '@jridgewell/remapping@2.3.5':
+    dependencies:
+      '@jridgewell/gen-mapping': 0.3.13
+      '@jridgewell/trace-mapping': 0.3.31
+
   '@jridgewell/resolve-uri@3.1.2': {}
 
   '@jridgewell/set-array@1.2.1': {}
@@ -9029,6 +9715,8 @@ snapshots:
       '@jridgewell/trace-mapping': 0.3.25
 
   '@jridgewell/sourcemap-codec@1.5.0': {}
+
+  '@jridgewell/sourcemap-codec@1.5.5': {}
 
   '@jridgewell/trace-mapping@0.3.25':
     dependencies:
@@ -9082,6 +9770,12 @@ snapshots:
     transitivePeerDependencies:
       - encoding
       - supports-color
+
+  '@miyaneee/rollup-plugin-json5@1.2.0(rollup@4.40.1)':
+    dependencies:
+      '@rollup/pluginutils': 5.1.4(rollup@4.40.1)
+      json5: 2.2.3
+      rollup: 4.40.1
 
   '@napi-rs/wasm-runtime@0.2.9':
     dependencies:
@@ -9240,12 +9934,12 @@ snapshots:
 
   '@nuxt/devalue@2.0.2': {}
 
-  '@nuxt/devtools-kit@2.4.0(magicast@0.3.5)(vite@6.3.4(@types/node@22.15.3)(jiti@2.6.1)(lightningcss@1.29.2)(terser@5.39.0)(yaml@2.7.1))':
+  '@nuxt/devtools-kit@2.4.0(magicast@0.3.5)(vite@6.3.4(@types/node@22.15.3)(jiti@2.6.1)(lightningcss@1.29.2)(terser@5.39.0)(yaml@2.9.0))':
     dependencies:
       '@nuxt/kit': 3.17.1(magicast@0.3.5)
       '@nuxt/schema': 3.17.1
       execa: 8.0.1
-      vite: 6.3.4(@types/node@22.15.3)(jiti@2.6.1)(lightningcss@1.29.2)(terser@5.39.0)(yaml@2.7.1)
+      vite: 6.3.4(@types/node@22.15.3)(jiti@2.6.1)(lightningcss@1.29.2)(terser@5.39.0)(yaml@2.9.0)
     transitivePeerDependencies:
       - magicast
 
@@ -9260,12 +9954,12 @@ snapshots:
       prompts: 2.4.2
       semver: 7.7.3
 
-  '@nuxt/devtools@2.4.0(vite@6.3.4(@types/node@22.15.3)(jiti@2.6.1)(lightningcss@1.29.2)(terser@5.39.0)(yaml@2.7.1))(vue@3.5.13(typescript@5.8.3))':
+  '@nuxt/devtools@2.4.0(vite@6.3.4(@types/node@22.15.3)(jiti@2.6.1)(lightningcss@1.29.2)(terser@5.39.0)(yaml@2.9.0))(vue@3.5.13(typescript@5.8.3))':
     dependencies:
-      '@nuxt/devtools-kit': 2.4.0(magicast@0.3.5)(vite@6.3.4(@types/node@22.15.3)(jiti@2.6.1)(lightningcss@1.29.2)(terser@5.39.0)(yaml@2.7.1))
+      '@nuxt/devtools-kit': 2.4.0(magicast@0.3.5)(vite@6.3.4(@types/node@22.15.3)(jiti@2.6.1)(lightningcss@1.29.2)(terser@5.39.0)(yaml@2.9.0))
       '@nuxt/devtools-wizard': 2.4.0
       '@nuxt/kit': 3.17.1(magicast@0.3.5)
-      '@vue/devtools-core': 7.7.6(vite@6.3.4(@types/node@22.15.3)(jiti@2.6.1)(lightningcss@1.29.2)(terser@5.39.0)(yaml@2.7.1))(vue@3.5.13(typescript@5.8.3))
+      '@vue/devtools-core': 7.7.6(vite@6.3.4(@types/node@22.15.3)(jiti@2.6.1)(lightningcss@1.29.2)(terser@5.39.0)(yaml@2.9.0))(vue@3.5.13(typescript@5.8.3))
       '@vue/devtools-kit': 7.7.6
       birpc: 2.3.0
       consola: 3.4.2
@@ -9290,9 +9984,9 @@ snapshots:
       sirv: 3.0.1
       structured-clone-es: 1.0.0
       tinyglobby: 0.2.15
-      vite: 6.3.4(@types/node@22.15.3)(jiti@2.6.1)(lightningcss@1.29.2)(terser@5.39.0)(yaml@2.7.1)
-      vite-plugin-inspect: 11.0.1(@nuxt/kit@3.17.1(magicast@0.3.5))(vite@6.3.4(@types/node@22.15.3)(jiti@2.6.1)(lightningcss@1.29.2)(terser@5.39.0)(yaml@2.7.1))
-      vite-plugin-vue-tracer: 0.1.3(vite@6.3.4(@types/node@22.15.3)(jiti@2.6.1)(lightningcss@1.29.2)(terser@5.39.0)(yaml@2.7.1))(vue@3.5.13(typescript@5.8.3))
+      vite: 6.3.4(@types/node@22.15.3)(jiti@2.6.1)(lightningcss@1.29.2)(terser@5.39.0)(yaml@2.9.0)
+      vite-plugin-inspect: 11.0.1(@nuxt/kit@3.17.1(magicast@0.3.5))(vite@6.3.4(@types/node@22.15.3)(jiti@2.6.1)(lightningcss@1.29.2)(terser@5.39.0)(yaml@2.9.0))
+      vite-plugin-vue-tracer: 0.1.3(vite@6.3.4(@types/node@22.15.3)(jiti@2.6.1)(lightningcss@1.29.2)(terser@5.39.0)(yaml@2.9.0))(vue@3.5.13(typescript@5.8.3))
       which: 5.0.0
       ws: 8.18.1
     transitivePeerDependencies:
@@ -9301,7 +9995,7 @@ snapshots:
       - utf-8-validate
       - vue
 
-  '@nuxt/eslint-config@1.3.0(@vue/compiler-sfc@3.5.13)(eslint@9.25.1(jiti@2.6.1))(typescript@5.8.3)':
+  '@nuxt/eslint-config@1.3.0(@vue/compiler-sfc@3.5.35)(eslint@9.25.1(jiti@2.6.1))(typescript@5.8.3)':
     dependencies:
       '@antfu/install-pkg': 1.0.0
       '@clack/prompts': 0.10.1
@@ -9319,7 +10013,7 @@ snapshots:
       eslint-plugin-regexp: 2.7.0(eslint@9.25.1(jiti@2.6.1))
       eslint-plugin-unicorn: 58.0.0(eslint@9.25.1(jiti@2.6.1))
       eslint-plugin-vue: 10.1.0(eslint@9.25.1(jiti@2.6.1))(vue-eslint-parser@10.1.3(eslint@9.25.1(jiti@2.6.1)))
-      eslint-processor-vue-blocks: 2.0.0(@vue/compiler-sfc@3.5.13)(eslint@9.25.1(jiti@2.6.1))
+      eslint-processor-vue-blocks: 2.0.0(@vue/compiler-sfc@3.5.35)(eslint@9.25.1(jiti@2.6.1))
       globals: 16.0.0
       local-pkg: 1.1.1
       pathe: 2.0.3
@@ -9338,11 +10032,11 @@ snapshots:
       - supports-color
       - typescript
 
-  '@nuxt/eslint@1.3.0(@vue/compiler-sfc@3.5.13)(eslint@9.25.1(jiti@2.6.1))(magicast@0.3.5)(typescript@5.8.3)(vite@6.3.4(@types/node@22.15.3)(jiti@2.6.1)(lightningcss@1.29.2)(terser@5.39.0)(yaml@2.7.1))':
+  '@nuxt/eslint@1.3.0(@vue/compiler-sfc@3.5.35)(eslint@9.25.1(jiti@2.6.1))(magicast@0.3.5)(typescript@5.8.3)(vite@6.3.4(@types/node@22.15.3)(jiti@2.6.1)(lightningcss@1.29.2)(terser@5.39.0)(yaml@2.9.0))':
     dependencies:
       '@eslint/config-inspector': 1.0.2(eslint@9.25.1(jiti@2.6.1))
-      '@nuxt/devtools-kit': 2.4.0(magicast@0.3.5)(vite@6.3.4(@types/node@22.15.3)(jiti@2.6.1)(lightningcss@1.29.2)(terser@5.39.0)(yaml@2.7.1))
-      '@nuxt/eslint-config': 1.3.0(@vue/compiler-sfc@3.5.13)(eslint@9.25.1(jiti@2.6.1))(typescript@5.8.3)
+      '@nuxt/devtools-kit': 2.4.0(magicast@0.3.5)(vite@6.3.4(@types/node@22.15.3)(jiti@2.6.1)(lightningcss@1.29.2)(terser@5.39.0)(yaml@2.9.0))
+      '@nuxt/eslint-config': 1.3.0(@vue/compiler-sfc@3.5.35)(eslint@9.25.1(jiti@2.6.1))(typescript@5.8.3)
       '@nuxt/eslint-plugin': 1.3.0(eslint@9.25.1(jiti@2.6.1))(typescript@5.8.3)
       '@nuxt/kit': 3.17.1(magicast@0.3.5)
       chokidar: 4.0.3
@@ -9364,9 +10058,9 @@ snapshots:
       - utf-8-validate
       - vite
 
-  '@nuxt/fonts@0.11.2(@netlify/blobs@8.2.0)(db0@0.3.2)(ioredis@5.6.1)(magicast@0.3.5)(vite@6.3.4(@types/node@22.15.3)(jiti@2.6.1)(lightningcss@1.29.2)(terser@5.39.0)(yaml@2.7.1))':
+  '@nuxt/fonts@0.11.2(@netlify/blobs@8.2.0)(db0@0.3.2)(ioredis@5.6.1)(magicast@0.3.5)(vite@6.3.4(@types/node@22.15.3)(jiti@2.6.1)(lightningcss@1.29.2)(terser@5.39.0)(yaml@2.9.0))':
     dependencies:
-      '@nuxt/devtools-kit': 2.4.0(magicast@0.3.5)(vite@6.3.4(@types/node@22.15.3)(jiti@2.6.1)(lightningcss@1.29.2)(terser@5.39.0)(yaml@2.7.1))
+      '@nuxt/devtools-kit': 2.4.0(magicast@0.3.5)(vite@6.3.4(@types/node@22.15.3)(jiti@2.6.1)(lightningcss@1.29.2)(terser@5.39.0)(yaml@2.9.0))
       '@nuxt/kit': 3.17.1(magicast@0.3.5)
       consola: 3.4.2
       css-tree: 3.1.0
@@ -9410,13 +10104,13 @@ snapshots:
       - uploadthing
       - vite
 
-  '@nuxt/icon@1.12.0(magicast@0.3.5)(vite@6.3.4(@types/node@22.15.3)(jiti@2.6.1)(lightningcss@1.29.2)(terser@5.39.0)(yaml@2.7.1))(vue@3.5.13(typescript@5.8.3))':
+  '@nuxt/icon@1.12.0(magicast@0.3.5)(vite@6.3.4(@types/node@22.15.3)(jiti@2.6.1)(lightningcss@1.29.2)(terser@5.39.0)(yaml@2.9.0))(vue@3.5.13(typescript@5.8.3))':
     dependencies:
       '@iconify/collections': 1.0.543
       '@iconify/types': 2.0.0
       '@iconify/utils': 2.3.0
       '@iconify/vue': 4.3.0(vue@3.5.13(typescript@5.8.3))
-      '@nuxt/devtools-kit': 2.4.0(magicast@0.3.5)(vite@6.3.4(@types/node@22.15.3)(jiti@2.6.1)(lightningcss@1.29.2)(terser@5.39.0)(yaml@2.7.1))
+      '@nuxt/devtools-kit': 2.4.0(magicast@0.3.5)(vite@6.3.4(@types/node@22.15.3)(jiti@2.6.1)(lightningcss@1.29.2)(terser@5.39.0)(yaml@2.9.0))
       '@nuxt/kit': 3.17.1(magicast@0.3.5)
       consola: 3.4.2
       local-pkg: 1.1.1
@@ -9495,6 +10189,32 @@ snapshots:
     transitivePeerDependencies:
       - magicast
 
+  '@nuxt/kit@3.21.6(magicast@0.3.5)':
+    dependencies:
+      c12: 3.3.4(magicast@0.3.5)
+      consola: 3.4.2
+      defu: 6.1.7
+      destr: 2.0.5
+      errx: 0.1.0
+      exsolve: 1.0.8
+      ignore: 7.0.5
+      jiti: 2.7.0
+      klona: 2.0.6
+      knitwork: 1.3.0
+      mlly: 1.8.2
+      ohash: 2.0.11
+      pathe: 2.0.3
+      pkg-types: 2.3.1
+      rc9: 3.0.1
+      scule: 1.3.0
+      semver: 7.8.1
+      tinyglobby: 0.2.17
+      ufo: 1.6.4
+      unctx: 2.5.0
+      untyped: 2.0.0
+    transitivePeerDependencies:
+      - magicast
+
   '@nuxt/kit@4.2.2(magicast@0.3.5)':
     dependencies:
       c12: 3.3.3(magicast@0.3.5)
@@ -9545,19 +10265,19 @@ snapshots:
     transitivePeerDependencies:
       - magicast
 
-  '@nuxt/ui@3.1.0(@babel/parser@7.28.5)(@netlify/blobs@8.2.0)(change-case@5.4.4)(db0@0.3.2)(embla-carousel@8.6.0)(ioredis@5.6.1)(jwt-decode@4.0.0)(magicast@0.3.5)(typescript@5.8.3)(vite@6.3.4(@types/node@22.15.3)(jiti@2.6.1)(lightningcss@1.29.2)(terser@5.39.0)(yaml@2.7.1))(vue-router@4.5.1(vue@3.5.13(typescript@5.8.3)))(vue@3.5.13(typescript@5.8.3))(zod@3.24.3)':
+  '@nuxt/ui@3.1.0(@babel/parser@7.29.7)(@netlify/blobs@8.2.0)(change-case@5.4.4)(db0@0.3.2)(embla-carousel@8.6.0)(ioredis@5.6.1)(jwt-decode@4.0.0)(magicast@0.3.5)(typescript@5.8.3)(vite@6.3.4(@types/node@22.15.3)(jiti@2.6.1)(lightningcss@1.29.2)(terser@5.39.0)(yaml@2.9.0))(vue-router@4.5.1(vue@3.5.13(typescript@5.8.3)))(vue@3.5.13(typescript@5.8.3))(zod@3.24.3)':
     dependencies:
       '@iconify/vue': 4.3.0(vue@3.5.13(typescript@5.8.3))
       '@internationalized/date': 3.8.0
       '@internationalized/number': 3.6.1
-      '@nuxt/fonts': 0.11.2(@netlify/blobs@8.2.0)(db0@0.3.2)(ioredis@5.6.1)(magicast@0.3.5)(vite@6.3.4(@types/node@22.15.3)(jiti@2.6.1)(lightningcss@1.29.2)(terser@5.39.0)(yaml@2.7.1))
-      '@nuxt/icon': 1.12.0(magicast@0.3.5)(vite@6.3.4(@types/node@22.15.3)(jiti@2.6.1)(lightningcss@1.29.2)(terser@5.39.0)(yaml@2.7.1))(vue@3.5.13(typescript@5.8.3))
+      '@nuxt/fonts': 0.11.2(@netlify/blobs@8.2.0)(db0@0.3.2)(ioredis@5.6.1)(magicast@0.3.5)(vite@6.3.4(@types/node@22.15.3)(jiti@2.6.1)(lightningcss@1.29.2)(terser@5.39.0)(yaml@2.9.0))
+      '@nuxt/icon': 1.12.0(magicast@0.3.5)(vite@6.3.4(@types/node@22.15.3)(jiti@2.6.1)(lightningcss@1.29.2)(terser@5.39.0)(yaml@2.9.0))(vue@3.5.13(typescript@5.8.3))
       '@nuxt/kit': 3.17.1(magicast@0.3.5)
       '@nuxt/schema': 3.17.1
       '@nuxtjs/color-mode': 3.5.2(magicast@0.3.5)
       '@standard-schema/spec': 1.0.0
       '@tailwindcss/postcss': 4.1.5
-      '@tailwindcss/vite': 4.1.5(vite@6.3.4(@types/node@22.15.3)(jiti@2.6.1)(lightningcss@1.29.2)(terser@5.39.0)(yaml@2.7.1))
+      '@tailwindcss/vite': 4.1.5(vite@6.3.4(@types/node@22.15.3)(jiti@2.6.1)(lightningcss@1.29.2)(terser@5.39.0)(yaml@2.9.0))
       '@tanstack/vue-table': 8.21.3(vue@3.5.13(typescript@5.8.3))
       '@unhead/vue': 2.0.8(vue@3.5.13(typescript@5.8.3))
       '@vueuse/core': 13.1.0(vue@3.5.13(typescript@5.8.3))
@@ -9587,7 +10307,7 @@ snapshots:
       typescript: 5.8.3
       unplugin: 2.3.2
       unplugin-auto-import: 19.1.2(@nuxt/kit@3.17.1(magicast@0.3.5))(@vueuse/core@13.1.0(vue@3.5.13(typescript@5.8.3)))
-      unplugin-vue-components: 28.5.0(@babel/parser@7.28.5)(@nuxt/kit@3.17.1(magicast@0.3.5))(vue@3.5.13(typescript@5.8.3))
+      unplugin-vue-components: 28.5.0(@babel/parser@7.29.7)(@nuxt/kit@3.17.1(magicast@0.3.5))(vue@3.5.13(typescript@5.8.3))
       vaul-vue: 0.4.1(reka-ui@2.2.0(typescript@5.8.3)(vue@3.5.13(typescript@5.8.3)))(vue@3.5.13(typescript@5.8.3))
     optionalDependencies:
       vue-router: 4.5.1(vue@3.5.13(typescript@5.8.3))
@@ -9631,12 +10351,12 @@ snapshots:
       - vite
       - vue
 
-  '@nuxt/vite-builder@3.17.1(@types/node@22.15.3)(eslint@9.25.1(jiti@2.6.1))(lightningcss@1.29.2)(magicast@0.3.5)(optionator@0.9.4)(rolldown@1.0.0-beta.57)(rollup@4.40.1)(terser@5.39.0)(typescript@5.8.3)(vue-tsc@2.2.10(typescript@5.8.3))(vue@3.5.13(typescript@5.8.3))(yaml@2.7.1)':
+  '@nuxt/vite-builder@3.17.1(@types/node@22.15.3)(eslint@9.25.1(jiti@2.6.1))(lightningcss@1.29.2)(magicast@0.3.5)(optionator@0.9.4)(rolldown@1.0.0-beta.57)(rollup@4.40.1)(terser@5.39.0)(typescript@5.8.3)(vue-tsc@2.2.10(typescript@5.8.3))(vue@3.5.13(typescript@5.8.3))(yaml@2.9.0)':
     dependencies:
       '@nuxt/kit': 3.17.1(magicast@0.3.5)
       '@rollup/plugin-replace': 6.0.2(rollup@4.40.1)
-      '@vitejs/plugin-vue': 5.2.3(vite@6.3.4(@types/node@22.15.3)(jiti@2.6.1)(lightningcss@1.29.2)(terser@5.39.0)(yaml@2.7.1))(vue@3.5.13(typescript@5.8.3))
-      '@vitejs/plugin-vue-jsx': 4.1.2(vite@6.3.4(@types/node@22.15.3)(jiti@2.6.1)(lightningcss@1.29.2)(terser@5.39.0)(yaml@2.7.1))(vue@3.5.13(typescript@5.8.3))
+      '@vitejs/plugin-vue': 5.2.3(vite@6.3.4(@types/node@22.15.3)(jiti@2.6.1)(lightningcss@1.29.2)(terser@5.39.0)(yaml@2.9.0))(vue@3.5.13(typescript@5.8.3))
+      '@vitejs/plugin-vue-jsx': 4.1.2(vite@6.3.4(@types/node@22.15.3)(jiti@2.6.1)(lightningcss@1.29.2)(terser@5.39.0)(yaml@2.9.0))(vue@3.5.13(typescript@5.8.3))
       autoprefixer: 10.4.21(postcss@8.5.3)
       consola: 3.4.2
       cssnano: 7.0.6(postcss@8.5.3)
@@ -9662,9 +10382,9 @@ snapshots:
       ufo: 1.6.1
       unenv: 2.0.0-rc.15
       unplugin: 2.3.2
-      vite: 6.3.4(@types/node@22.15.3)(jiti@2.6.1)(lightningcss@1.29.2)(terser@5.39.0)(yaml@2.7.1)
-      vite-node: 3.1.2(@types/node@22.15.3)(jiti@2.6.1)(lightningcss@1.29.2)(terser@5.39.0)(yaml@2.7.1)
-      vite-plugin-checker: 0.9.1(eslint@9.25.1(jiti@2.6.1))(optionator@0.9.4)(typescript@5.8.3)(vite@6.3.4(@types/node@22.15.3)(jiti@2.6.1)(lightningcss@1.29.2)(terser@5.39.0)(yaml@2.7.1))(vue-tsc@2.2.10(typescript@5.8.3))
+      vite: 6.3.4(@types/node@22.15.3)(jiti@2.6.1)(lightningcss@1.29.2)(terser@5.39.0)(yaml@2.9.0)
+      vite-node: 3.1.2(@types/node@22.15.3)(jiti@2.6.1)(lightningcss@1.29.2)(terser@5.39.0)(yaml@2.9.0)
+      vite-plugin-checker: 0.9.1(eslint@9.25.1(jiti@2.6.1))(optionator@0.9.4)(typescript@5.8.3)(vite@6.3.4(@types/node@22.15.3)(jiti@2.6.1)(lightningcss@1.29.2)(terser@5.39.0)(yaml@2.9.0))(vue-tsc@2.2.10(typescript@5.8.3))
       vue: 3.5.13(typescript@5.8.3)
       vue-bundle-renderer: 2.1.1
     transitivePeerDependencies:
@@ -9761,25 +10481,94 @@ snapshots:
     transitivePeerDependencies:
       - magicast
 
+  '@nuxtjs/i18n@9.5.6(@vue/compiler-dom@3.5.35)(eslint@9.25.1(jiti@2.6.1))(magicast@0.3.5)(rollup@4.40.1)(vue@3.5.13(typescript@5.8.3))':
+    dependencies:
+      '@intlify/h3': 0.6.1
+      '@intlify/shared': 10.0.8
+      '@intlify/unplugin-vue-i18n': 6.0.8(@vue/compiler-dom@3.5.35)(eslint@9.25.1(jiti@2.6.1))(rollup@4.40.1)(typescript@5.8.3)(vue-i18n@10.0.8(vue@3.5.13(typescript@5.8.3)))(vue@3.5.13(typescript@5.8.3))
+      '@intlify/utils': 0.13.0
+      '@miyaneee/rollup-plugin-json5': 1.2.0(rollup@4.40.1)
+      '@nuxt/kit': 3.21.6(magicast@0.3.5)
+      '@oxc-parser/wasm': 0.60.0
+      '@rollup/plugin-yaml': 4.1.2(rollup@4.40.1)
+      '@vue/compiler-sfc': 3.5.35
+      debug: 4.4.0
+      defu: 6.1.7
+      esbuild: 0.25.12
+      estree-walker: 3.0.3
+      h3: 1.15.4
+      knitwork: 1.2.0
+      magic-string: 0.30.21
+      mlly: 1.8.2
+      oxc-parser: 0.70.0
+      pathe: 2.0.3
+      typescript: 5.8.3
+      ufo: 1.6.4
+      unplugin: 2.3.11
+      unplugin-vue-router: 0.12.0(vue-router@4.5.1(vue@3.5.13(typescript@5.8.3)))(vue@3.5.13(typescript@5.8.3))
+      vue-i18n: 10.0.8(vue@3.5.13(typescript@5.8.3))
+      vue-router: 4.5.1(vue@3.5.13(typescript@5.8.3))
+    transitivePeerDependencies:
+      - '@vue/compiler-dom'
+      - eslint
+      - magicast
+      - petite-vue-i18n
+      - rollup
+      - supports-color
+      - vue
+
   '@oxc-parser/binding-darwin-arm64@0.67.0':
+    optional: true
+
+  '@oxc-parser/binding-darwin-arm64@0.70.0':
     optional: true
 
   '@oxc-parser/binding-darwin-x64@0.67.0':
     optional: true
 
+  '@oxc-parser/binding-darwin-x64@0.70.0':
+    optional: true
+
+  '@oxc-parser/binding-freebsd-x64@0.70.0':
+    optional: true
+
   '@oxc-parser/binding-linux-arm-gnueabihf@0.67.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-arm-gnueabihf@0.70.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-arm-musleabihf@0.70.0':
     optional: true
 
   '@oxc-parser/binding-linux-arm64-gnu@0.67.0':
     optional: true
 
+  '@oxc-parser/binding-linux-arm64-gnu@0.70.0':
+    optional: true
+
   '@oxc-parser/binding-linux-arm64-musl@0.67.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-arm64-musl@0.70.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-riscv64-gnu@0.70.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-s390x-gnu@0.70.0':
     optional: true
 
   '@oxc-parser/binding-linux-x64-gnu@0.67.0':
     optional: true
 
+  '@oxc-parser/binding-linux-x64-gnu@0.70.0':
+    optional: true
+
   '@oxc-parser/binding-linux-x64-musl@0.67.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-x64-musl@0.70.0':
     optional: true
 
   '@oxc-parser/binding-wasm32-wasi@0.67.0':
@@ -9787,15 +10576,34 @@ snapshots:
       '@napi-rs/wasm-runtime': 0.2.9
     optional: true
 
+  '@oxc-parser/binding-wasm32-wasi@0.70.0':
+    dependencies:
+      '@napi-rs/wasm-runtime': 0.2.9
+    optional: true
+
   '@oxc-parser/binding-win32-arm64-msvc@0.67.0':
+    optional: true
+
+  '@oxc-parser/binding-win32-arm64-msvc@0.70.0':
     optional: true
 
   '@oxc-parser/binding-win32-x64-msvc@0.67.0':
     optional: true
 
+  '@oxc-parser/binding-win32-x64-msvc@0.70.0':
+    optional: true
+
+  '@oxc-parser/wasm@0.60.0':
+    dependencies:
+      '@oxc-project/types': 0.60.0
+
   '@oxc-project/types@0.103.0': {}
 
+  '@oxc-project/types@0.60.0': {}
+
   '@oxc-project/types@0.67.0': {}
+
+  '@oxc-project/types@0.70.0': {}
 
   '@parcel/watcher-android-arm64@2.5.1':
     optional: true
@@ -10041,6 +10849,14 @@ snapshots:
     optionalDependencies:
       rollup: 4.40.1
 
+  '@rollup/plugin-yaml@4.1.2(rollup@4.40.1)':
+    dependencies:
+      '@rollup/pluginutils': 5.1.4(rollup@4.40.1)
+      js-yaml: 4.1.0
+      tosource: 2.0.0-alpha.3
+    optionalDependencies:
+      rollup: 4.40.1
+
   '@rollup/pluginutils@3.1.0(rollup@2.79.2)':
     dependencies:
       '@types/estree': 0.0.39
@@ -10225,12 +11041,12 @@ snapshots:
       postcss: 8.5.3
       tailwindcss: 4.1.5
 
-  '@tailwindcss/vite@4.1.5(vite@6.3.4(@types/node@22.15.3)(jiti@2.6.1)(lightningcss@1.29.2)(terser@5.39.0)(yaml@2.7.1))':
+  '@tailwindcss/vite@4.1.5(vite@6.3.4(@types/node@22.15.3)(jiti@2.6.1)(lightningcss@1.29.2)(terser@5.39.0)(yaml@2.9.0))':
     dependencies:
       '@tailwindcss/node': 4.1.5
       '@tailwindcss/oxide': 4.1.5
       tailwindcss: 4.1.5
-      vite: 6.3.4(@types/node@22.15.3)(jiti@2.6.1)(lightningcss@1.29.2)(terser@5.39.0)(yaml@2.7.1)
+      vite: 6.3.4(@types/node@22.15.3)(jiti@2.6.1)(lightningcss@1.29.2)(terser@5.39.0)(yaml@2.9.0)
 
   '@tanstack/table-core@8.21.3': {}
 
@@ -10493,12 +11309,12 @@ snapshots:
       sharp-ico: 0.1.5
       unconfig: 7.3.2
 
-  '@vite-pwa/nuxt@1.0.0(@vite-pwa/assets-generator@1.0.0)(magicast@0.3.5)(vite@6.3.4(@types/node@22.15.3)(jiti@2.6.1)(lightningcss@1.29.2)(terser@5.39.0)(yaml@2.7.1))(workbox-build@7.3.0)(workbox-window@7.3.0)':
+  '@vite-pwa/nuxt@1.0.0(@vite-pwa/assets-generator@1.0.0)(magicast@0.3.5)(vite@6.3.4(@types/node@22.15.3)(jiti@2.6.1)(lightningcss@1.29.2)(terser@5.39.0)(yaml@2.9.0))(workbox-build@7.3.0)(workbox-window@7.3.0)':
     dependencies:
       '@nuxt/kit': 3.17.1(magicast@0.3.5)
       pathe: 1.1.2
       ufo: 1.6.1
-      vite-plugin-pwa: 1.0.0(@vite-pwa/assets-generator@1.0.0)(vite@6.3.4(@types/node@22.15.3)(jiti@2.6.1)(lightningcss@1.29.2)(terser@5.39.0)(yaml@2.7.1))(workbox-build@7.3.0)(workbox-window@7.3.0)
+      vite-plugin-pwa: 1.0.0(@vite-pwa/assets-generator@1.0.0)(vite@6.3.4(@types/node@22.15.3)(jiti@2.6.1)(lightningcss@1.29.2)(terser@5.39.0)(yaml@2.9.0))(workbox-build@7.3.0)(workbox-window@7.3.0)
     optionalDependencies:
       '@vite-pwa/assets-generator': 1.0.0
     transitivePeerDependencies:
@@ -10508,19 +11324,19 @@ snapshots:
       - workbox-build
       - workbox-window
 
-  '@vitejs/plugin-vue-jsx@4.1.2(vite@6.3.4(@types/node@22.15.3)(jiti@2.6.1)(lightningcss@1.29.2)(terser@5.39.0)(yaml@2.7.1))(vue@3.5.13(typescript@5.8.3))':
+  '@vitejs/plugin-vue-jsx@4.1.2(vite@6.3.4(@types/node@22.15.3)(jiti@2.6.1)(lightningcss@1.29.2)(terser@5.39.0)(yaml@2.9.0))(vue@3.5.13(typescript@5.8.3))':
     dependencies:
       '@babel/core': 7.27.1
       '@babel/plugin-transform-typescript': 7.27.1(@babel/core@7.27.1)
       '@vue/babel-plugin-jsx': 1.4.0(@babel/core@7.27.1)
-      vite: 6.3.4(@types/node@22.15.3)(jiti@2.6.1)(lightningcss@1.29.2)(terser@5.39.0)(yaml@2.7.1)
+      vite: 6.3.4(@types/node@22.15.3)(jiti@2.6.1)(lightningcss@1.29.2)(terser@5.39.0)(yaml@2.9.0)
       vue: 3.5.13(typescript@5.8.3)
     transitivePeerDependencies:
       - supports-color
 
-  '@vitejs/plugin-vue@5.2.3(vite@6.3.4(@types/node@22.15.3)(jiti@2.6.1)(lightningcss@1.29.2)(terser@5.39.0)(yaml@2.7.1))(vue@3.5.13(typescript@5.8.3))':
+  '@vitejs/plugin-vue@5.2.3(vite@6.3.4(@types/node@22.15.3)(jiti@2.6.1)(lightningcss@1.29.2)(terser@5.39.0)(yaml@2.9.0))(vue@3.5.13(typescript@5.8.3))':
     dependencies:
-      vite: 6.3.4(@types/node@22.15.3)(jiti@2.6.1)(lightningcss@1.29.2)(terser@5.39.0)(yaml@2.7.1)
+      vite: 6.3.4(@types/node@22.15.3)(jiti@2.6.1)(lightningcss@1.29.2)(terser@5.39.0)(yaml@2.9.0)
       vue: 3.5.13(typescript@5.8.3)
 
   '@volar/language-core@2.4.13':
@@ -10583,10 +11399,23 @@ snapshots:
       estree-walker: 2.0.2
       source-map-js: 1.2.1
 
+  '@vue/compiler-core@3.5.35':
+    dependencies:
+      '@babel/parser': 7.29.7
+      '@vue/shared': 3.5.35
+      entities: 7.0.1
+      estree-walker: 2.0.2
+      source-map-js: 1.2.1
+
   '@vue/compiler-dom@3.5.13':
     dependencies:
       '@vue/compiler-core': 3.5.13
       '@vue/shared': 3.5.13
+
+  '@vue/compiler-dom@3.5.35':
+    dependencies:
+      '@vue/compiler-core': 3.5.35
+      '@vue/shared': 3.5.35
 
   '@vue/compiler-sfc@3.5.13':
     dependencies:
@@ -10600,10 +11429,27 @@ snapshots:
       postcss: 8.5.3
       source-map-js: 1.2.1
 
+  '@vue/compiler-sfc@3.5.35':
+    dependencies:
+      '@babel/parser': 7.29.7
+      '@vue/compiler-core': 3.5.35
+      '@vue/compiler-dom': 3.5.35
+      '@vue/compiler-ssr': 3.5.35
+      '@vue/shared': 3.5.35
+      estree-walker: 2.0.2
+      magic-string: 0.30.21
+      postcss: 8.5.15
+      source-map-js: 1.2.1
+
   '@vue/compiler-ssr@3.5.13':
     dependencies:
       '@vue/compiler-dom': 3.5.13
       '@vue/shared': 3.5.13
+
+  '@vue/compiler-ssr@3.5.35':
+    dependencies:
+      '@vue/compiler-dom': 3.5.35
+      '@vue/shared': 3.5.35
 
   '@vue/compiler-vue2@2.7.16':
     dependencies:
@@ -10612,14 +11458,14 @@ snapshots:
 
   '@vue/devtools-api@6.6.4': {}
 
-  '@vue/devtools-core@7.7.6(vite@6.3.4(@types/node@22.15.3)(jiti@2.6.1)(lightningcss@1.29.2)(terser@5.39.0)(yaml@2.7.1))(vue@3.5.13(typescript@5.8.3))':
+  '@vue/devtools-core@7.7.6(vite@6.3.4(@types/node@22.15.3)(jiti@2.6.1)(lightningcss@1.29.2)(terser@5.39.0)(yaml@2.9.0))(vue@3.5.13(typescript@5.8.3))':
     dependencies:
       '@vue/devtools-kit': 7.7.6
       '@vue/devtools-shared': 7.7.6
       mitt: 3.0.1
       nanoid: 5.1.5
       pathe: 2.0.3
-      vite-hot-client: 2.0.4(vite@6.3.4(@types/node@22.15.3)(jiti@2.6.1)(lightningcss@1.29.2)(terser@5.39.0)(yaml@2.7.1))
+      vite-hot-client: 2.0.4(vite@6.3.4(@types/node@22.15.3)(jiti@2.6.1)(lightningcss@1.29.2)(terser@5.39.0)(yaml@2.9.0))
       vue: 3.5.13(typescript@5.8.3)
     transitivePeerDependencies:
       - vite
@@ -10674,6 +11520,8 @@ snapshots:
       vue: 3.5.13(typescript@5.8.3)
 
   '@vue/shared@3.5.13': {}
+
+  '@vue/shared@3.5.35': {}
 
   '@vueuse/core@10.11.1(vue@3.5.13(typescript@5.8.3))':
     dependencies:
@@ -10778,11 +11626,17 @@ snapshots:
     dependencies:
       acorn: 8.15.0
 
+  acorn-jsx@5.3.2(acorn@8.16.0):
+    dependencies:
+      acorn: 8.16.0
+
   acorn-walk@8.3.2: {}
 
   acorn@8.14.0: {}
 
   acorn@8.15.0: {}
+
+  acorn@8.16.0: {}
 
   agent-base@6.0.2:
     dependencies:
@@ -11055,6 +11909,23 @@ snapshots:
     optionalDependencies:
       magicast: 0.3.5
 
+  c12@3.3.4(magicast@0.3.5):
+    dependencies:
+      chokidar: 5.0.0
+      confbox: 0.2.4
+      defu: 6.1.7
+      dotenv: 17.4.2
+      exsolve: 1.0.8
+      giget: 3.2.0
+      jiti: 2.7.0
+      ohash: 2.0.11
+      pathe: 2.0.3
+      perfect-debounce: 2.1.0
+      pkg-types: 2.3.1
+      rc9: 3.0.1
+    optionalDependencies:
+      magicast: 0.3.5
+
   cac@6.7.14: {}
 
   call-bind-apply-helpers@1.0.2:
@@ -11217,6 +12088,8 @@ snapshots:
   confbox@0.1.8: {}
 
   confbox@0.2.2: {}
+
+  confbox@0.2.4: {}
 
   consola@3.4.2: {}
 
@@ -11441,6 +12314,8 @@ snapshots:
 
   defu@6.1.4: {}
 
+  defu@6.1.7: {}
+
   delegates@1.0.0: {}
 
   denque@2.1.0: {}
@@ -11535,6 +12410,8 @@ snapshots:
 
   dotenv@17.2.3: {}
 
+  dotenv@17.4.2: {}
+
   dts-resolver@2.1.3: {}
 
   dunder-proto@1.0.1:
@@ -11612,6 +12489,8 @@ snapshots:
       tapable: 2.2.1
 
   entities@4.5.0: {}
+
+  entities@7.0.1: {}
 
   env-paths@3.0.0: {}
 
@@ -11721,6 +12600,35 @@ snapshots:
       '@esbuild/win32-arm64': 0.19.11
       '@esbuild/win32-ia32': 0.19.11
       '@esbuild/win32-x64': 0.19.11
+
+  esbuild@0.25.12:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.25.12
+      '@esbuild/android-arm': 0.25.12
+      '@esbuild/android-arm64': 0.25.12
+      '@esbuild/android-x64': 0.25.12
+      '@esbuild/darwin-arm64': 0.25.12
+      '@esbuild/darwin-x64': 0.25.12
+      '@esbuild/freebsd-arm64': 0.25.12
+      '@esbuild/freebsd-x64': 0.25.12
+      '@esbuild/linux-arm': 0.25.12
+      '@esbuild/linux-arm64': 0.25.12
+      '@esbuild/linux-ia32': 0.25.12
+      '@esbuild/linux-loong64': 0.25.12
+      '@esbuild/linux-mips64el': 0.25.12
+      '@esbuild/linux-ppc64': 0.25.12
+      '@esbuild/linux-riscv64': 0.25.12
+      '@esbuild/linux-s390x': 0.25.12
+      '@esbuild/linux-x64': 0.25.12
+      '@esbuild/netbsd-arm64': 0.25.12
+      '@esbuild/netbsd-x64': 0.25.12
+      '@esbuild/openbsd-arm64': 0.25.12
+      '@esbuild/openbsd-x64': 0.25.12
+      '@esbuild/openharmony-arm64': 0.25.12
+      '@esbuild/sunos-x64': 0.25.12
+      '@esbuild/win32-arm64': 0.25.12
+      '@esbuild/win32-ia32': 0.25.12
+      '@esbuild/win32-x64': 0.25.12
 
   esbuild@0.25.2:
     optionalDependencies:
@@ -11894,9 +12802,9 @@ snapshots:
       vue-eslint-parser: 10.1.3(eslint@9.25.1(jiti@2.6.1))
       xml-name-validator: 4.0.0
 
-  eslint-processor-vue-blocks@2.0.0(@vue/compiler-sfc@3.5.13)(eslint@9.25.1(jiti@2.6.1)):
+  eslint-processor-vue-blocks@2.0.0(@vue/compiler-sfc@3.5.35)(eslint@9.25.1(jiti@2.6.1)):
     dependencies:
-      '@vue/compiler-sfc': 3.5.13
+      '@vue/compiler-sfc': 3.5.35
       eslint: 9.25.1(jiti@2.6.1)
 
   eslint-scope@8.3.0:
@@ -11961,6 +12869,12 @@ snapshots:
       acorn: 8.15.0
       acorn-jsx: 5.3.2(acorn@8.15.0)
       eslint-visitor-keys: 4.2.0
+
+  espree@9.6.1:
+    dependencies:
+      acorn: 8.16.0
+      acorn-jsx: 5.3.2(acorn@8.16.0)
+      eslint-visitor-keys: 3.4.3
 
   esprima@4.0.1: {}
 
@@ -12091,6 +13005,10 @@ snapshots:
   fdir@6.5.0(picomatch@4.0.3):
     optionalDependencies:
       picomatch: 4.0.3
+
+  fdir@6.5.0(picomatch@4.0.4):
+    optionalDependencies:
+      picomatch: 4.0.4
 
   fecha@4.2.3: {}
 
@@ -12338,6 +13256,8 @@ snapshots:
       nypm: 0.6.2
       pathe: 2.0.3
 
+  giget@3.2.0: {}
+
   git-up@8.1.1:
     dependencies:
       is-ssh: 1.4.1
@@ -12448,12 +13368,12 @@ snapshots:
     dependencies:
       cookie-es: 1.2.2
       crossws: 0.3.5
-      defu: 6.1.4
+      defu: 6.1.7
       destr: 2.0.5
       iron-webcrypto: 1.2.1
       node-mock-http: 1.0.4
       radix3: 1.1.2
-      ufo: 1.6.1
+      ufo: 1.6.4
       uncrypto: 0.1.3
 
   has-bigints@1.1.0: {}
@@ -12837,6 +13757,8 @@ snapshots:
 
   jiti@2.6.1: {}
 
+  jiti@2.7.0: {}
+
   js-tokens@4.0.0: {}
 
   js-tokens@9.0.1: {}
@@ -12868,6 +13790,13 @@ snapshots:
 
   json5@2.2.3: {}
 
+  jsonc-eslint-parser@2.4.2:
+    dependencies:
+      acorn: 8.16.0
+      eslint-visitor-keys: 3.4.3
+      espree: 9.6.1
+      semver: 7.8.1
+
   jsonfile@6.1.0:
     dependencies:
       universalify: 2.0.1
@@ -12891,6 +13820,8 @@ snapshots:
   klona@2.0.6: {}
 
   knitwork@1.2.0: {}
+
+  knitwork@1.3.0: {}
 
   kolorist@1.8.0: {}
 
@@ -13063,6 +13994,10 @@ snapshots:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.0
 
+  magic-string@0.30.21:
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+
   magicast@0.3.5:
     dependencies:
       '@babel/parser': 7.27.1
@@ -13184,6 +14119,13 @@ snapshots:
       pkg-types: 1.3.1
       ufo: 1.6.1
 
+  mlly@1.8.2:
+    dependencies:
+      acorn: 8.16.0
+      pathe: 2.0.3
+      pkg-types: 1.3.1
+      ufo: 1.6.4
+
   mocked-exports@0.1.1: {}
 
   module-definition@5.0.1:
@@ -13200,6 +14142,8 @@ snapshots:
   mustache@4.2.0: {}
 
   nanoid@3.3.11: {}
+
+  nanoid@3.3.12: {}
 
   nanoid@5.1.5: {}
 
@@ -13391,15 +14335,15 @@ snapshots:
     dependencies:
       boolbase: 1.0.0
 
-  nuxt@3.17.1(@netlify/blobs@8.2.0)(@parcel/watcher@2.5.1)(@types/node@22.15.3)(db0@0.3.2)(eslint@9.25.1(jiti@2.6.1))(ioredis@5.6.1)(lightningcss@1.29.2)(magicast@0.3.5)(optionator@0.9.4)(rolldown@1.0.0-beta.57)(rollup@4.40.1)(terser@5.39.0)(typescript@5.8.3)(vite@6.3.4(@types/node@22.15.3)(jiti@2.6.1)(lightningcss@1.29.2)(terser@5.39.0)(yaml@2.7.1))(vue-tsc@2.2.10(typescript@5.8.3))(yaml@2.7.1):
+  nuxt@3.17.1(@netlify/blobs@8.2.0)(@parcel/watcher@2.5.1)(@types/node@22.15.3)(db0@0.3.2)(eslint@9.25.1(jiti@2.6.1))(ioredis@5.6.1)(lightningcss@1.29.2)(magicast@0.3.5)(optionator@0.9.4)(rolldown@1.0.0-beta.57)(rollup@4.40.1)(terser@5.39.0)(typescript@5.8.3)(vite@6.3.4(@types/node@22.15.3)(jiti@2.6.1)(lightningcss@1.29.2)(terser@5.39.0)(yaml@2.9.0))(vue-tsc@2.2.10(typescript@5.8.3))(yaml@2.9.0):
     dependencies:
       '@nuxt/cli': 3.25.0(magicast@0.3.5)
       '@nuxt/devalue': 2.0.2
-      '@nuxt/devtools': 2.4.0(vite@6.3.4(@types/node@22.15.3)(jiti@2.6.1)(lightningcss@1.29.2)(terser@5.39.0)(yaml@2.7.1))(vue@3.5.13(typescript@5.8.3))
+      '@nuxt/devtools': 2.4.0(vite@6.3.4(@types/node@22.15.3)(jiti@2.6.1)(lightningcss@1.29.2)(terser@5.39.0)(yaml@2.9.0))(vue@3.5.13(typescript@5.8.3))
       '@nuxt/kit': 3.17.1(magicast@0.3.5)
       '@nuxt/schema': 3.17.1
       '@nuxt/telemetry': 2.6.6(magicast@0.3.5)
-      '@nuxt/vite-builder': 3.17.1(@types/node@22.15.3)(eslint@9.25.1(jiti@2.6.1))(lightningcss@1.29.2)(magicast@0.3.5)(optionator@0.9.4)(rolldown@1.0.0-beta.57)(rollup@4.40.1)(terser@5.39.0)(typescript@5.8.3)(vue-tsc@2.2.10(typescript@5.8.3))(vue@3.5.13(typescript@5.8.3))(yaml@2.7.1)
+      '@nuxt/vite-builder': 3.17.1(@types/node@22.15.3)(eslint@9.25.1(jiti@2.6.1))(lightningcss@1.29.2)(magicast@0.3.5)(optionator@0.9.4)(rolldown@1.0.0-beta.57)(rollup@4.40.1)(terser@5.39.0)(typescript@5.8.3)(vue-tsc@2.2.10(typescript@5.8.3))(vue@3.5.13(typescript@5.8.3))(yaml@2.9.0)
       '@unhead/vue': 2.0.8(vue@3.5.13(typescript@5.8.3))
       '@vue/shared': 3.5.13
       c12: 3.0.3(magicast@0.3.5)
@@ -13620,6 +14564,25 @@ snapshots:
       '@oxc-parser/binding-win32-arm64-msvc': 0.67.0
       '@oxc-parser/binding-win32-x64-msvc': 0.67.0
 
+  oxc-parser@0.70.0:
+    dependencies:
+      '@oxc-project/types': 0.70.0
+    optionalDependencies:
+      '@oxc-parser/binding-darwin-arm64': 0.70.0
+      '@oxc-parser/binding-darwin-x64': 0.70.0
+      '@oxc-parser/binding-freebsd-x64': 0.70.0
+      '@oxc-parser/binding-linux-arm-gnueabihf': 0.70.0
+      '@oxc-parser/binding-linux-arm-musleabihf': 0.70.0
+      '@oxc-parser/binding-linux-arm64-gnu': 0.70.0
+      '@oxc-parser/binding-linux-arm64-musl': 0.70.0
+      '@oxc-parser/binding-linux-riscv64-gnu': 0.70.0
+      '@oxc-parser/binding-linux-s390x-gnu': 0.70.0
+      '@oxc-parser/binding-linux-x64-gnu': 0.70.0
+      '@oxc-parser/binding-linux-x64-musl': 0.70.0
+      '@oxc-parser/binding-wasm32-wasi': 0.70.0
+      '@oxc-parser/binding-win32-arm64-msvc': 0.70.0
+      '@oxc-parser/binding-win32-x64-msvc': 0.70.0
+
   p-event@5.0.1:
     dependencies:
       p-timeout: 5.1.0
@@ -13724,6 +14687,8 @@ snapshots:
 
   perfect-debounce@2.0.0: {}
 
+  perfect-debounce@2.1.0: {}
+
   picocolors@1.1.1: {}
 
   picomatch@2.3.1: {}
@@ -13731,6 +14696,8 @@ snapshots:
   picomatch@4.0.2: {}
 
   picomatch@4.0.3: {}
+
+  picomatch@4.0.4: {}
 
   pkg-types@1.3.1:
     dependencies:
@@ -13747,6 +14714,12 @@ snapshots:
   pkg-types@2.3.0:
     dependencies:
       confbox: 0.2.2
+      exsolve: 1.0.8
+      pathe: 2.0.3
+
+  pkg-types@2.3.1:
+    dependencies:
+      confbox: 0.2.4
       exsolve: 1.0.8
       pathe: 2.0.3
 
@@ -13922,6 +14895,12 @@ snapshots:
       postcss: 8.5.3
       quote-unquote: 1.0.0
 
+  postcss@8.5.15:
+    dependencies:
+      nanoid: 3.3.12
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
+
   postcss@8.5.3:
     dependencies:
       nanoid: 3.3.11
@@ -14017,6 +14996,11 @@ snapshots:
   rc9@2.1.2:
     dependencies:
       defu: 6.1.4
+      destr: 2.0.5
+
+  rc9@3.0.1:
+    dependencies:
+      defu: 6.1.7
       destr: 2.0.5
 
   read-package-up@11.0.0:
@@ -14303,6 +15287,8 @@ snapshots:
   semver@7.7.1: {}
 
   semver@7.7.3: {}
+
+  semver@7.8.1: {}
 
   send@1.2.0:
     dependencies:
@@ -14766,6 +15752,11 @@ snapshots:
       fdir: 6.5.0(picomatch@4.0.3)
       picomatch: 4.0.3
 
+  tinyglobby@0.2.17:
+    dependencies:
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
+
   tmp-promise@3.0.3:
     dependencies:
       tmp: 0.2.3
@@ -14781,6 +15772,8 @@ snapshots:
   toidentifier@1.0.1: {}
 
   toml@3.0.0: {}
+
+  tosource@2.0.0-alpha.3: {}
 
   totalist@3.0.1: {}
 
@@ -14881,6 +15874,8 @@ snapshots:
 
   ufo@1.6.1: {}
 
+  ufo@1.6.4: {}
+
   ultrahtml@1.6.0: {}
 
   unbox-primitive@1.1.0:
@@ -14910,6 +15905,13 @@ snapshots:
       estree-walker: 3.0.3
       magic-string: 0.30.17
       unplugin: 2.3.2
+
+  unctx@2.5.0:
+    dependencies:
+      acorn: 8.16.0
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+      unplugin: 2.3.11
 
   undici-types@6.21.0: {}
 
@@ -15020,7 +16022,7 @@ snapshots:
       pathe: 2.0.3
       picomatch: 4.0.2
 
-  unplugin-vue-components@28.5.0(@babel/parser@7.28.5)(@nuxt/kit@3.17.1(magicast@0.3.5))(vue@3.5.13(typescript@5.8.3)):
+  unplugin-vue-components@28.5.0(@babel/parser@7.29.7)(@nuxt/kit@3.17.1(magicast@0.3.5))(vue@3.5.13(typescript@5.8.3)):
     dependencies:
       chokidar: 3.6.0
       debug: 4.4.0
@@ -15032,7 +16034,7 @@ snapshots:
       unplugin-utils: 0.2.4
       vue: 3.5.13(typescript@5.8.3)
     optionalDependencies:
-      '@babel/parser': 7.28.5
+      '@babel/parser': 7.29.7
       '@nuxt/kit': 3.17.1(magicast@0.3.5)
     transitivePeerDependencies:
       - supports-color
@@ -15062,6 +16064,13 @@ snapshots:
   unplugin@1.16.1:
     dependencies:
       acorn: 8.15.0
+      webpack-virtual-modules: 0.6.2
+
+  unplugin@2.3.11:
+    dependencies:
+      '@jridgewell/remapping': 2.3.5
+      acorn: 8.16.0
+      picomatch: 4.0.4
       webpack-virtual-modules: 0.6.2
 
   unplugin@2.3.2:
@@ -15184,23 +16193,23 @@ snapshots:
     transitivePeerDependencies:
       - '@vue/composition-api'
 
-  vite-dev-rpc@1.0.7(vite@6.3.4(@types/node@22.15.3)(jiti@2.6.1)(lightningcss@1.29.2)(terser@5.39.0)(yaml@2.7.1)):
+  vite-dev-rpc@1.0.7(vite@6.3.4(@types/node@22.15.3)(jiti@2.6.1)(lightningcss@1.29.2)(terser@5.39.0)(yaml@2.9.0)):
     dependencies:
       birpc: 2.3.0
-      vite: 6.3.4(@types/node@22.15.3)(jiti@2.6.1)(lightningcss@1.29.2)(terser@5.39.0)(yaml@2.7.1)
-      vite-hot-client: 2.0.4(vite@6.3.4(@types/node@22.15.3)(jiti@2.6.1)(lightningcss@1.29.2)(terser@5.39.0)(yaml@2.7.1))
+      vite: 6.3.4(@types/node@22.15.3)(jiti@2.6.1)(lightningcss@1.29.2)(terser@5.39.0)(yaml@2.9.0)
+      vite-hot-client: 2.0.4(vite@6.3.4(@types/node@22.15.3)(jiti@2.6.1)(lightningcss@1.29.2)(terser@5.39.0)(yaml@2.9.0))
 
-  vite-hot-client@2.0.4(vite@6.3.4(@types/node@22.15.3)(jiti@2.6.1)(lightningcss@1.29.2)(terser@5.39.0)(yaml@2.7.1)):
+  vite-hot-client@2.0.4(vite@6.3.4(@types/node@22.15.3)(jiti@2.6.1)(lightningcss@1.29.2)(terser@5.39.0)(yaml@2.9.0)):
     dependencies:
-      vite: 6.3.4(@types/node@22.15.3)(jiti@2.6.1)(lightningcss@1.29.2)(terser@5.39.0)(yaml@2.7.1)
+      vite: 6.3.4(@types/node@22.15.3)(jiti@2.6.1)(lightningcss@1.29.2)(terser@5.39.0)(yaml@2.9.0)
 
-  vite-node@3.1.2(@types/node@22.15.3)(jiti@2.6.1)(lightningcss@1.29.2)(terser@5.39.0)(yaml@2.7.1):
+  vite-node@3.1.2(@types/node@22.15.3)(jiti@2.6.1)(lightningcss@1.29.2)(terser@5.39.0)(yaml@2.9.0):
     dependencies:
       cac: 6.7.14
       debug: 4.4.0
       es-module-lexer: 1.7.0
       pathe: 2.0.3
-      vite: 6.3.4(@types/node@22.15.3)(jiti@2.6.1)(lightningcss@1.29.2)(terser@5.39.0)(yaml@2.7.1)
+      vite: 6.3.4(@types/node@22.15.3)(jiti@2.6.1)(lightningcss@1.29.2)(terser@5.39.0)(yaml@2.9.0)
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -15215,7 +16224,7 @@ snapshots:
       - tsx
       - yaml
 
-  vite-plugin-checker@0.9.1(eslint@9.25.1(jiti@2.6.1))(optionator@0.9.4)(typescript@5.8.3)(vite@6.3.4(@types/node@22.15.3)(jiti@2.6.1)(lightningcss@1.29.2)(terser@5.39.0)(yaml@2.7.1))(vue-tsc@2.2.10(typescript@5.8.3)):
+  vite-plugin-checker@0.9.1(eslint@9.25.1(jiti@2.6.1))(optionator@0.9.4)(typescript@5.8.3)(vite@6.3.4(@types/node@22.15.3)(jiti@2.6.1)(lightningcss@1.29.2)(terser@5.39.0)(yaml@2.9.0))(vue-tsc@2.2.10(typescript@5.8.3)):
     dependencies:
       '@babel/code-frame': 7.27.1
       chokidar: 4.0.3
@@ -15225,7 +16234,7 @@ snapshots:
       strip-ansi: 7.1.0
       tiny-invariant: 1.3.3
       tinyglobby: 0.2.15
-      vite: 6.3.4(@types/node@22.15.3)(jiti@2.6.1)(lightningcss@1.29.2)(terser@5.39.0)(yaml@2.7.1)
+      vite: 6.3.4(@types/node@22.15.3)(jiti@2.6.1)(lightningcss@1.29.2)(terser@5.39.0)(yaml@2.9.0)
       vscode-uri: 3.1.0
     optionalDependencies:
       eslint: 9.25.1(jiti@2.6.1)
@@ -15233,7 +16242,7 @@ snapshots:
       typescript: 5.8.3
       vue-tsc: 2.2.10(typescript@5.8.3)
 
-  vite-plugin-inspect@11.0.1(@nuxt/kit@3.17.1(magicast@0.3.5))(vite@6.3.4(@types/node@22.15.3)(jiti@2.6.1)(lightningcss@1.29.2)(terser@5.39.0)(yaml@2.7.1)):
+  vite-plugin-inspect@11.0.1(@nuxt/kit@3.17.1(magicast@0.3.5))(vite@6.3.4(@types/node@22.15.3)(jiti@2.6.1)(lightningcss@1.29.2)(terser@5.39.0)(yaml@2.9.0)):
     dependencies:
       ansis: 3.17.0
       debug: 4.4.0
@@ -15243,19 +16252,19 @@ snapshots:
       perfect-debounce: 1.0.0
       sirv: 3.0.1
       unplugin-utils: 0.2.4
-      vite: 6.3.4(@types/node@22.15.3)(jiti@2.6.1)(lightningcss@1.29.2)(terser@5.39.0)(yaml@2.7.1)
-      vite-dev-rpc: 1.0.7(vite@6.3.4(@types/node@22.15.3)(jiti@2.6.1)(lightningcss@1.29.2)(terser@5.39.0)(yaml@2.7.1))
+      vite: 6.3.4(@types/node@22.15.3)(jiti@2.6.1)(lightningcss@1.29.2)(terser@5.39.0)(yaml@2.9.0)
+      vite-dev-rpc: 1.0.7(vite@6.3.4(@types/node@22.15.3)(jiti@2.6.1)(lightningcss@1.29.2)(terser@5.39.0)(yaml@2.9.0))
     optionalDependencies:
       '@nuxt/kit': 3.17.1(magicast@0.3.5)
     transitivePeerDependencies:
       - supports-color
 
-  vite-plugin-pwa@1.0.0(@vite-pwa/assets-generator@1.0.0)(vite@6.3.4(@types/node@22.15.3)(jiti@2.6.1)(lightningcss@1.29.2)(terser@5.39.0)(yaml@2.7.1))(workbox-build@7.3.0)(workbox-window@7.3.0):
+  vite-plugin-pwa@1.0.0(@vite-pwa/assets-generator@1.0.0)(vite@6.3.4(@types/node@22.15.3)(jiti@2.6.1)(lightningcss@1.29.2)(terser@5.39.0)(yaml@2.9.0))(workbox-build@7.3.0)(workbox-window@7.3.0):
     dependencies:
       debug: 4.4.0
       pretty-bytes: 6.1.1
       tinyglobby: 0.2.13
-      vite: 6.3.4(@types/node@22.15.3)(jiti@2.6.1)(lightningcss@1.29.2)(terser@5.39.0)(yaml@2.7.1)
+      vite: 6.3.4(@types/node@22.15.3)(jiti@2.6.1)(lightningcss@1.29.2)(terser@5.39.0)(yaml@2.9.0)
       workbox-build: 7.3.0
       workbox-window: 7.3.0
     optionalDependencies:
@@ -15263,17 +16272,17 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  vite-plugin-vue-tracer@0.1.3(vite@6.3.4(@types/node@22.15.3)(jiti@2.6.1)(lightningcss@1.29.2)(terser@5.39.0)(yaml@2.7.1))(vue@3.5.13(typescript@5.8.3)):
+  vite-plugin-vue-tracer@0.1.3(vite@6.3.4(@types/node@22.15.3)(jiti@2.6.1)(lightningcss@1.29.2)(terser@5.39.0)(yaml@2.9.0))(vue@3.5.13(typescript@5.8.3)):
     dependencies:
       estree-walker: 3.0.3
       exsolve: 1.0.8
       magic-string: 0.30.17
       pathe: 2.0.3
       source-map-js: 1.2.1
-      vite: 6.3.4(@types/node@22.15.3)(jiti@2.6.1)(lightningcss@1.29.2)(terser@5.39.0)(yaml@2.7.1)
+      vite: 6.3.4(@types/node@22.15.3)(jiti@2.6.1)(lightningcss@1.29.2)(terser@5.39.0)(yaml@2.9.0)
       vue: 3.5.13(typescript@5.8.3)
 
-  vite@6.3.4(@types/node@22.15.3)(jiti@2.6.1)(lightningcss@1.29.2)(terser@5.39.0)(yaml@2.7.1):
+  vite@6.3.4(@types/node@22.15.3)(jiti@2.6.1)(lightningcss@1.29.2)(terser@5.39.0)(yaml@2.9.0):
     dependencies:
       esbuild: 0.25.3
       fdir: 6.4.4(picomatch@4.0.2)
@@ -15287,7 +16296,7 @@ snapshots:
       jiti: 2.6.1
       lightningcss: 1.29.2
       terser: 5.39.0
-      yaml: 2.7.1
+      yaml: 2.9.0
 
   vscode-uri@3.1.0: {}
 
@@ -15313,6 +16322,13 @@ snapshots:
       semver: 7.7.3
     transitivePeerDependencies:
       - supports-color
+
+  vue-i18n@10.0.8(vue@3.5.13(typescript@5.8.3)):
+    dependencies:
+      '@intlify/core-base': 10.0.8
+      '@intlify/shared': 10.0.8
+      '@vue/devtools-api': 6.6.4
+      vue: 3.5.13(typescript@5.8.3)
 
   vue-router@4.5.1(vue@3.5.13(typescript@5.8.3)):
     dependencies:
@@ -15619,7 +16635,14 @@ snapshots:
 
   yallist@5.0.0: {}
 
+  yaml-eslint-parser@1.3.2:
+    dependencies:
+      eslint-visitor-keys: 3.4.3
+      yaml: 2.9.0
+
   yaml@2.7.1: {}
+
+  yaml@2.9.0: {}
 
   yargs-parser@21.1.1: {}
 


### PR DESCRIPTION
Intègre @nuxtjs/i18n (v9) pour proposer l'application en anglais, français, allemand, espagnol, italien et chinois.

- Stratégie no_prefix : langue mémorisée par cookie + détection navigateur, sans changer les URLs (QR codes des cafés préservés)
- Langue par défaut : anglais (repli)
- 6 fichiers de langue (i18n/locales/*.json), ~365 clés namespacées couvrant landing, auth, setup, menu client, dashboard barista, CRUD menu, paramètres café, toasts, statuts, démo
- Composant LanguageSwitcher réutilisable (navbar landing, auth, menu client, paramètres café, dashboard menu)
- app.vue : attribut <html lang> et meta description synchronisés avec la locale active
- Textes riches via <i18n-t> (titre hero, bloc « à propos », ligne de confirmation de suppression de compte)
- Échappe le « @ » des placeholders email ({'@'}) pour la compilation vue-i18n